### PR TITLE
ApiWrapper methods PUT by id: qualifying & matching questions

### DIFF
--- a/app/src/components/ProfileEdit/MatchingQuestionPage.tsx
+++ b/app/src/components/ProfileEdit/MatchingQuestionPage.tsx
@@ -67,7 +67,7 @@ const IconContainer = (props: {
 }
 
 export const MatchingQuestionPage = (props: MatchingQuestionPageProps) => {
-    // const { data, putHostReponse } = useHostDashboardData()
+    const { data, putMatchingResponse } = useHostDashboardData()
     // console.log('testing custom hook', data)
 
     // sort by order
@@ -191,7 +191,7 @@ export const MatchingQuestionPage = (props: MatchingQuestionPageProps) => {
         //     hostId: 1,
         //     responseValues: [1],
         // }
-        // await putHostResponse(state.groupIndex, testResponse)
+        // await putMatchingResponse(state.groupIndex, testResponse)
 
         if (state.subgroupIndex < groups[state.groupIndex].length - 1) {
             setState({ ...state, subgroupIndex: state.subgroupIndex + 1 })

--- a/app/src/components/ProfileEdit/QuestionPage.tsx
+++ b/app/src/components/ProfileEdit/QuestionPage.tsx
@@ -66,7 +66,7 @@ const IconContainer = (props: {
 }
 
 export const QuestionPage = (props: Props) => {
-    const { data, putHostResponse } = useHostDashboardData()
+    const { data } = useHostDashboardData()
     console.log('testing custom hook', data)
 
     // sort by order

--- a/app/src/components/ProfileEdit/ShowstopperQuestionPage.tsx
+++ b/app/src/components/ProfileEdit/ShowstopperQuestionPage.tsx
@@ -68,7 +68,7 @@ const IconContainer = (props: {
 export const ShowstopperQuestionPage = (
     props: ShowstopperQuestionPageProps
 ) => {
-    // const { data, putHostResponse } = useHostDashboardData()
+    const { data, putShowstopperResponse } = useHostDashboardData()
     // console.log('testing custom hook', data)
 
     // sort by order
@@ -192,7 +192,7 @@ export const ShowstopperQuestionPage = (
         //     hostId: 1,
         //     responseValues: [1],
         // }
-        // await putHostResponse(state.groupIndex, testResponse)
+        // await putShowstopperResponse(state.groupIndex, testResponse)
         if (state.subgroupIndex < groups[state.groupIndex].length - 1) {
             setState({ ...state, subgroupIndex: state.subgroupIndex + 1 })
         } else if (state.groupIndex < groups.length - 1) {

--- a/app/src/data/ApiWrapper.ts
+++ b/app/src/data/ApiWrapper.ts
@@ -106,7 +106,7 @@ export class ApiWrapper {
     private hostShowstopperResponse: Fetcher<string>
     private hostMatchingResponse: Fetcher<string>
 
-    public constructor(id?: number | string, email?: string) {
+    public constructor(id?: number | string) {
         this.guestFetcher = new Fetcher<Guest>('guests')
         this.hostShowstopperQuestionsFetcher = new Fetcher<
             ShowstopperQuestionType
@@ -126,10 +126,10 @@ export class ApiWrapper {
             `/api/v1/hostRegisterQuestions/${id}`
         )
         this.hostShowstopperResponse = new Fetcher<string>(
-            `/api/v1/hostRegisterQuestions/${email}`
+            `/api/host/registration/qualifying/${id}`
         )
         this.hostMatchingResponse = new Fetcher<string>(
-            `/api/v1/hostRegisterQuestions/${email}`
+            `/api/host/registration/matching/${id}`
         )
     }
 
@@ -188,16 +188,16 @@ export class ApiWrapper {
     }
 
     public async putShowstopperQuestionResponse(
-        email: string,
+        id: number | string,
         item: HostResponse
     ): Promise<string> {
-        return await this.hostShowstopperResponse.putById(email, item)
+        return await this.hostShowstopperResponse.putById(id, item)
     }
 
     public async putMatchingQuestionResponse(
-        email: string,
+        id: number | string,
         item: HostResponse
     ): Promise<string> {
-        return await this.hostMatchingResponse.putById(email, item)
+        return await this.hostMatchingResponse.putById(id, item)
     }
 }

--- a/app/src/data/ApiWrapper.ts
+++ b/app/src/data/ApiWrapper.ts
@@ -103,8 +103,10 @@ export class ApiWrapper {
     private hostLanguageForm: Fetcher<string>
     private hostGenderForm: Fetcher<string>
     private hostQuestionsResponse: Fetcher<string>
+    private hostShowstopperResponse: Fetcher<string>
+    private hostMatchingResponse: Fetcher<string>
 
-    public constructor(id?: number | string) {
+    public constructor(id?: number | string, email?: string) {
         this.guestFetcher = new Fetcher<Guest>('guests')
         this.hostShowstopperQuestionsFetcher = new Fetcher<
             ShowstopperQuestionType
@@ -122,6 +124,12 @@ export class ApiWrapper {
         this.hostGenderForm = new Fetcher<string>(`host/registration/language`)
         this.hostQuestionsResponse = new Fetcher<string>(
             `/api/v1/hostRegisterQuestions/${id}`
+        )
+        this.hostShowstopperResponse = new Fetcher<string>(
+            `/api/v1/hostRegisterQuestions/${email}`
+        )
+        this.hostMatchingResponse = new Fetcher<string>(
+            `/api/v1/hostRegisterQuestions/${email}`
         )
     }
 
@@ -177,5 +185,19 @@ export class ApiWrapper {
         item: HostResponse
     ): Promise<string> {
         return await this.hostQuestionsResponse.putById(id, item)
+    }
+
+    public async putShowstopperQuestionResponse(
+        email: string,
+        item: HostResponse
+    ): Promise<string> {
+        return await this.hostShowstopperResponse.putById(email, item)
+    }
+
+    public async putMatchingQuestionResponse(
+        email: string,
+        item: HostResponse
+    ): Promise<string> {
+        return await this.hostMatchingResponse.putById(email, item)
     }
 }

--- a/app/src/data/ApiWrapper.ts
+++ b/app/src/data/ApiWrapper.ts
@@ -102,7 +102,6 @@ export class ApiWrapper {
     private hostAddressForm: Fetcher<string>
     private hostLanguageForm: Fetcher<string>
     private hostGenderForm: Fetcher<string>
-    private hostQuestionsResponse: Fetcher<string>
     private hostShowstopperResponse: Fetcher<string>
     private hostMatchingResponse: Fetcher<string>
 
@@ -122,14 +121,12 @@ export class ApiWrapper {
             `host/registration/language`
         )
         this.hostGenderForm = new Fetcher<string>(`host/registration/gender`)
-        this.hostQuestionsResponse = new Fetcher<string>(
-            `/api/v1/hostRegisterQuestions/${id}`
-        )
+
         this.hostShowstopperResponse = new Fetcher<string>(
-            `/api/host/registration/qualifying/${id}`
+            `/host/registration/qualifying/${id}`
         )
         this.hostMatchingResponse = new Fetcher<string>(
-            `/api/host/registration/matching/${id}`
+            `/host/registration/matching/${id}`
         )
     }
 
@@ -185,12 +182,6 @@ export class ApiWrapper {
     //    HostResponse may not be appropriate as currently defined,
     //        Matching PUT body: { "email": string, "response": Response ID(s) or a string }
     //question ID
-    public async putHostRegistrationResponse(
-        id: number | string,
-        item: HostResponse
-    ): Promise<string> {
-        return await this.hostQuestionsResponse.putById(id, item)
-    }
 
     public async putShowstopperQuestionResponse(
         id: number | string,

--- a/app/src/data/host-context.tsx
+++ b/app/src/data/host-context.tsx
@@ -763,7 +763,7 @@ export function useHostDashboardData() {
     }
 
     // showstopper & matching
-    const putHostResponse = async (
+    const putShowstopperResponse = async (
         id: number | string,
         hostResponse: HostResponse
     ) => {
@@ -771,14 +771,39 @@ export function useHostDashboardData() {
         try {
             dispatch({
                 type: HostDashboardActionType.BeginPostResponse,
-                payload: 'Posting host response...',
+                payload: 'Posting host qualifying response...',
             })
 
             await hostsFetcher.putHostRegistrationResponse(id, hostResponse)
 
             dispatch({
                 type: HostDashboardActionType.FinishPostResponse,
-                payload: 'Finished host response...',
+                payload: 'Finished host qualifying response...',
+            })
+        } catch (e) {
+            dispatch({
+                type: HostDashboardActionType.Error,
+                payload: `System error: ${e}`,
+            })
+        }
+    }
+
+    const putMatchingResponse = async (
+        id: number | string,
+        hostResponse: HostResponse
+    ) => {
+        console.log(`postHostResponse: ${hostResponse} `)
+        try {
+            dispatch({
+                type: HostDashboardActionType.BeginPostResponse,
+                payload: 'Posting host matching response...',
+            })
+
+            await hostsFetcher.putHostRegistrationResponse(id, hostResponse)
+
+            dispatch({
+                type: HostDashboardActionType.FinishPostResponse,
+                payload: 'Finished host matching response...',
             })
         } catch (e) {
             dispatch({
@@ -921,7 +946,8 @@ export function useHostDashboardData() {
         getMatchingQuestions,
         getShowstopperQuestionById,
         getMatchingQuestionById,
-        putHostResponse,
+        putShowstopperResponse,
+        putMatchingResponse,
         putPersonalInfo,
         putContactInfo,
         putAddressInfo,

--- a/app/src/data/host-context.tsx
+++ b/app/src/data/host-context.tsx
@@ -120,8 +120,19 @@ export function HostDashboardDataProvider(
 
                 const hostQuestions = await Promise.all([
                     hostsFetcher.getHostShowstopperQuestions(),
-                    await hostsFetcher.getHostMatchingQuestions(),
+                    hostsFetcher.getHostMatchingQuestions(),
                 ])
+
+                //set on state
+                const showstopperQuestionsMap = new Map()
+                hostQuestions[0].map((question) => {
+                    showstopperQuestionsMap.set(question.id, question)
+                })
+
+                const matchingQuestionsMap = new Map()
+                hostQuestions[1].map((question) => {
+                    matchingQuestionsMap.set(question.id, question)
+                })
 
                 dispatch({
                     type: HostDashboardActionType.FinishFetchQuestions,
@@ -882,6 +893,16 @@ export function useHostDashboardData() {
         }
     }
 
+    const getShowstopperQuestionById = (id: number) => {
+        //dispatch
+        //return showstopperQuestionMap[id]
+    }
+
+    const getMatchingQuestionById = (id: number) => {
+        //dispatch
+        //return matchingQuestionMap[id]
+    }
+
     const [data, dispatch] = context as [
         HostDashboardData,
         React.Dispatch<HostDashboardAction>
@@ -892,6 +913,8 @@ export function useHostDashboardData() {
         dispatch,
         getShowstopperQuestions,
         getMatchingQuestions,
+        getShowstopperQuestionById,
+        getMatchingQuestionById,
         putHostResponse,
         putPersonalInfo,
         putContactInfo,

--- a/app/src/data/host-context.tsx
+++ b/app/src/data/host-context.tsx
@@ -124,14 +124,20 @@ export function HostDashboardDataProvider(
                 ])
 
                 //set on state
-                const showstopperQuestionsMap = new Map()
-                hostQuestions[0].map((question) => {
-                    showstopperQuestionsMap.set(question.id, question)
+                const showstopperQuestionsMap = new Map<
+                    string,
+                    MatchingQuestionType
+                >()
+                hostQuestions[0].map((question: MatchingQuestionType) => {
+                    return showstopperQuestionsMap.set(question.id, question)
                 })
 
-                const matchingQuestionsMap = new Map()
-                hostQuestions[1].map((question) => {
-                    matchingQuestionsMap.set(question.id, question)
+                const matchingQuestionsMap = new Map<
+                    string,
+                    ShowstopperQuestionType
+                >()
+                hostQuestions[1].map((question: ShowstopperQuestionType) => {
+                    return matchingQuestionsMap.set(question.id, question)
                 })
 
                 dispatch({

--- a/app/src/data/host-context.tsx
+++ b/app/src/data/host-context.tsx
@@ -124,21 +124,21 @@ export function HostDashboardDataProvider(
                 ])
 
                 //set on state
-                const showstopperQuestionsMap = new Map<
-                    string,
-                    MatchingQuestionType
-                >()
-                hostQuestions[0].map((question: MatchingQuestionType) => {
-                    return showstopperQuestionsMap.set(question.id, question)
-                })
+                // const showstopperQuestionsMap = new Map<
+                //     string,
+                //     MatchingQuestionType
+                // >()
+                // hostQuestions[0].map((question: MatchingQuestionType) => {
+                //     return showstopperQuestionsMap.set(question.id, question)
+                // })
 
-                const matchingQuestionsMap = new Map<
-                    string,
-                    ShowstopperQuestionType
-                >()
-                hostQuestions[1].map((question: ShowstopperQuestionType) => {
-                    return matchingQuestionsMap.set(question.id, question)
-                })
+                // const matchingQuestionsMap = new Map<
+                //     string,
+                //     ShowstopperQuestionType
+                // >()
+                // hostQuestions[1].map((question: ShowstopperQuestionType) => {
+                //     return matchingQuestionsMap.set(question.id, question)
+                // })
 
                 dispatch({
                     type: HostDashboardActionType.FinishFetchQuestions,

--- a/app/src/data/host-context.tsx
+++ b/app/src/data/host-context.tsx
@@ -774,7 +774,7 @@ export function useHostDashboardData() {
                 payload: 'Posting host qualifying response...',
             })
 
-            await hostsFetcher.putHostRegistrationResponse(id, hostResponse)
+            await hostsFetcher.putShowstopperQuestionResponse(id, hostResponse)
 
             dispatch({
                 type: HostDashboardActionType.FinishPostResponse,
@@ -799,7 +799,7 @@ export function useHostDashboardData() {
                 payload: 'Posting host matching response...',
             })
 
-            await hostsFetcher.putHostRegistrationResponse(id, hostResponse)
+            await hostsFetcher.putMatchingQuestionResponse(id, hostResponse)
 
             dispatch({
                 type: HostDashboardActionType.FinishPostResponse,

--- a/app/src/models/HostResponse.ts
+++ b/app/src/models/HostResponse.ts
@@ -1,11 +1,12 @@
+/* v1 model */
 export interface HostResponse {
-    email: string
-    response: string | Array<number> | number
+    questionId: number
+    hostId: number
+    responseValues: Array<number>
 }
 
-/* v1 model */
+/*v2 model */
 // export interface HostResponse {
-//     questionId: number
-//     hostId: number
-//     responseValues: Array<number>
+//     email: string
+//     responseValues: string | Array<number> | number
 // }

--- a/app/src/models/HostResponse.ts
+++ b/app/src/models/HostResponse.ts
@@ -1,5 +1,11 @@
 export interface HostResponse {
-    questionId: number
-    hostId: number
-    responseValues: Array<number>
+    email: string
+    response: string | Array<number> | number
 }
+
+/* v1 model */
+// export interface HostResponse {
+//     questionId: number
+//     hostId: number
+//     responseValues: Array<number>
+// }

--- a/app/src/models/MatchingQuestionType.ts
+++ b/app/src/models/MatchingQuestionType.ts
@@ -1,7 +1,7 @@
 export interface MatchingQuestionType {
     id: string
     question: string
-    type: string
+    type?: string
     options?: Array<any>
     answer?: any
     group?: string

--- a/app/src/models/ShowstopperQuestionType.ts
+++ b/app/src/models/ShowstopperQuestionType.ts
@@ -1,5 +1,6 @@
 export interface ShowstopperQuestionType {
     id: string
+    type?: string
     question: string
     answer?: any
     group?: string


### PR DESCRIPTION
Addresses issue #234 

**Splits the generic putHostResponse method into two methods:**
- putMatchingResponse
- putShowstopperResponse

**Updates in files:**
- ApiWrapper
- host-context
- MatchingQuestion
- ShowstopperQuestion

Note: The proposed model is commented out for now as the current `HostResponse` model is in use in the data-context. A separate model could be created.
```
{ 
  email: string
  responseValues: string | Array<number> | number
}
```
Disregard any commented out code unrelated to issue #234 