### PR TITLE
Form redirection links

### DIFF
--- a/api/openapi_server/controllers/auth_controller.py
+++ b/api/openapi_server/controllers/auth_controller.py
@@ -191,7 +191,7 @@ def token():
     code = request.get_json()['code']
     client_id = COGNITO_CLIENT_ID
     client_secret = COGNITO_CLIENT_SECRET
-    callback_uri = 'http://localhost:4040/signin'
+    callback_uri = request.args['callback_uri']
     cognito_app_url = 'https://homeuudemo.auth.us-east-1.amazoncognito.com'
 
     token_url = f"{cognito_app_url}/oauth2/token"
@@ -348,5 +348,6 @@ def private(token_info):
 
 def google():
     # print hello
-    print('hello')
-    return redirect(f"https://homeuudemo.auth.us-east-1.amazoncognito.com/oauth2/authorize?client_id={COGNITO_CLIENT_ID}&response_type=code&scope=email+openid+phone+profile+aws.cognito.signin.user.admin&redirect_uri={COGNITO_REDIRECT_URI}&identity_provider=Google")
+    redirect_uri = request.args['redirect_uri']
+        
+    return redirect(f"https://homeuudemo.auth.us-east-1.amazoncognito.com/oauth2/authorize?client_id={COGNITO_CLIENT_ID}&response_type=code&scope=email+openid+phone+profile+aws.cognito.signin.user.admin&redirect_uri={redirect_uri}&identity_provider=Google")

--- a/app/src/components/authentication/SignInForm.tsx
+++ b/app/src/components/authentication/SignInForm.tsx
@@ -97,7 +97,7 @@ export const SignInForm = ({onSubmit}: SignInFormProps) => {
         fullWidth
         // overrides the default react router link since we're hitting a redirect from the api
         component="a"
-        href={'/api/auth/google'}
+        href={'/api/auth/google?redirect_uri=http://localhost:4040/signin'}
       >
         <GoogleIcon sx={{fontSize: 16, marginRight: 1}} /> Sign in with Google
       </Button>

--- a/app/src/components/authentication/SignInForm.tsx
+++ b/app/src/components/authentication/SignInForm.tsx
@@ -81,7 +81,7 @@ export const SignInForm = ({onSubmit}: SignInFormProps) => {
           <FormHelperText error>{errors.password}</FormHelperText>
         )}
       </Stack>
-      <Stack>
+      <Stack direction="row">
         <Link href="/forgot-password">forgot password?</Link>
       </Stack>
       <Button variant="contained" size="large" type="submit" fullWidth>

--- a/app/src/components/authentication/SignInForm.tsx
+++ b/app/src/components/authentication/SignInForm.tsx
@@ -82,21 +82,21 @@ export const SignInForm = ({onSubmit}: SignInFormProps) => {
         )}
       </Stack>
       <Stack direction="row">
-        <Link href="/forgot-password">forgot password?</Link>
+        <Link fontWeight="bold" href="/forgot-password">
+          forgot password?
+        </Link>
       </Stack>
       <Button variant="contained" size="large" type="submit" fullWidth>
         Sign in
       </Button>
       <Divider>or</Divider>
-      {/* <SocialSignInLink
-        fullWidth
-        href={`https://homeuudemo.auth.us-east-1.amazoncognito.com/oauth2/authorize?client_id=${import.meta.env.VITE_COGNITO_CLIENT_ID}&response_type=code&scope=email+openid+phone+profile+aws.cognito.signin.user.admin&redirect_uri=${import.meta.env.VITE_COGNITO_REDIRECT_URI}&identity_provider=Google`}
-      > */}
       <Button
         variant="outlined"
         color="secondary"
         size="large"
         fullWidth
+        // overrides the default react router link since we're hitting a redirect from the api
+        component="a"
         href={'/api/auth/google'}
       >
         <GoogleIcon sx={{fontSize: 16, marginRight: 1}} /> Sign in with Google

--- a/app/src/components/authentication/SignInForm.tsx
+++ b/app/src/components/authentication/SignInForm.tsx
@@ -6,6 +6,7 @@ import {
   Stack,
   styled,
   Divider,
+  Link,
 } from '@mui/material';
 import GoogleIcon from '@mui/icons-material/Google';
 import {useFormik} from 'formik';
@@ -79,6 +80,9 @@ export const SignInForm = ({onSubmit}: SignInFormProps) => {
         {touched.password && errors.password && (
           <FormHelperText error>{errors.password}</FormHelperText>
         )}
+      </Stack>
+      <Stack>
+        <Link href="/forgot-password">forgot password?</Link>
       </Stack>
       <Button variant="contained" size="large" type="submit" fullWidth>
         Sign in

--- a/app/src/components/authentication/SignUpForm.tsx
+++ b/app/src/components/authentication/SignUpForm.tsx
@@ -6,6 +6,8 @@ import {
   FormHelperText,
   Stack,
   Button,
+  Link,
+  Typography,
 } from '@mui/material';
 import {styled} from '@mui/system';
 import GoogleIcon from '@mui/icons-material/Google';
@@ -71,6 +73,10 @@ export const SignUpForm = ({onSubmit}: SignUpFormProps) => {
         {touched.password && errors.password && (
           <FormHelperText error>{errors.password}</FormHelperText>
         )}
+      </Stack>
+      <Stack direction="row" gap={1}>
+        <Typography>Already a member?</Typography>
+        <Link href="/signin">Sign in</Link>
       </Stack>
       <Button variant="contained" size="large" type="submit" fullWidth>
         Sign up

--- a/app/src/components/authentication/SignUpForm.tsx
+++ b/app/src/components/authentication/SignUpForm.tsx
@@ -91,7 +91,7 @@ export const SignUpForm = ({onSubmit}: SignUpFormProps) => {
         fullWidth
         // overrides the default react router link since we're hitting a redirect from the api
         component="a"
-        href={'/api/auth/google'}
+        href={'/api/auth/google?redirect_uri=http://localhost:4040/signup'}
       >
         <GoogleIcon sx={{fontSize: 16, marginRight: 1}} /> Sign up with Google
       </Button>

--- a/app/src/components/authentication/SignUpForm.tsx
+++ b/app/src/components/authentication/SignUpForm.tsx
@@ -76,7 +76,9 @@ export const SignUpForm = ({onSubmit}: SignUpFormProps) => {
       </Stack>
       <Stack direction="row" gap={1}>
         <Typography>Already a member?</Typography>
-        <Link href="/signin">Sign in</Link>
+        <Link fontWeight="bold" href="/signin">
+          Sign in
+        </Link>
       </Stack>
       <Button variant="contained" size="large" type="submit" fullWidth>
         Sign up
@@ -87,6 +89,8 @@ export const SignUpForm = ({onSubmit}: SignUpFormProps) => {
         color="secondary"
         size="large"
         fullWidth
+        // overrides the default react router link since we're hitting a redirect from the api
+        component="a"
         href={'/api/auth/google'}
       >
         <GoogleIcon sx={{fontSize: 16, marginRight: 1}} /> Sign up with Google

--- a/app/src/theme/overrides/Button.ts
+++ b/app/src/theme/overrides/Button.ts
@@ -1,11 +1,13 @@
 import {Theme} from '@mui/material';
 import {Components} from '@mui/material/styles';
+import {LinkBehavior} from './Link';
 
 export const Button = (theme: Theme): Components => {
   return {
     MuiButtonBase: {
       defaultProps: {
         disableRipple: true,
+        LinkComponent: LinkBehavior,
       },
     },
     MuiButton: {

--- a/app/src/theme/overrides/Link.tsx
+++ b/app/src/theme/overrides/Link.tsx
@@ -1,0 +1,29 @@
+import {LinkProps} from '@mui/material/Link';
+import {Components} from '@mui/material/styles';
+import React from 'react';
+import {
+  Link as RouterLink,
+  LinkProps as RouterLinkProps,
+} from 'react-router-dom';
+
+export const LinkBehavior = React.forwardRef<
+  never,
+  Omit<RouterLinkProps, 'to'> & {href: RouterLinkProps['to']}
+>((props, ref) => {
+  const {href, ...other} = props;
+  // Map href (MUI) -> to (react-router)
+  return <RouterLink ref={ref} to={href} {...other} />;
+});
+
+LinkBehavior.displayName = 'LinkBehavior';
+
+export const Link = (): Components => {
+  return {
+    MuiLink: {
+      defaultProps: {
+        component: LinkBehavior,
+        underline: 'hover',
+      } as LinkProps,
+    },
+  };
+};

--- a/app/src/theme/overrides/index.ts
+++ b/app/src/theme/overrides/index.ts
@@ -3,6 +3,7 @@ import {OutlinedInput} from './OutlinedInput';
 import {InputLabel} from './InputLabel';
 import {Button} from './Button';
 import {Divider} from './Divider';
+import {Link} from './Link';
 
 /**
  * Merge component overrides into a single object to be used by the theme.
@@ -17,6 +18,7 @@ export const componentOverrides = (theme: Theme) => {
     InputLabel(theme),
     Button(theme),
     Divider(theme),
+    Link(),
   ];
 
   // Reduce components into a single object

--- a/app/src/views/SignIn.tsx
+++ b/app/src/views/SignIn.tsx
@@ -24,7 +24,7 @@ export const SignIn = () => {
   React.useEffect(() => {
     if (location.search.includes('code')) {
       const code = location.search.split('?code=')[1];
-      fetch('/api/auth/token', {
+      fetch('/api/auth/token?callback_uri=http://localhost:4040/signin', {
         headers: {
           'Content-Type': 'application/json',
         },

--- a/app/src/views/SignIn.tsx
+++ b/app/src/views/SignIn.tsx
@@ -12,8 +12,8 @@ export interface LocationState {
 }
 
 export const SignIn = () => {
-  const navigate = useNavigate();
   const location = useLocation();
+  const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const [signIn] = useSignInMutation();
   const locationState = location.state as LocationState;
@@ -32,9 +32,10 @@ export const SignIn = () => {
         body: JSON.stringify({code}),
       })
         .then(res => res.json())
-        .then(data => {
-          console.log('data', data);
-          navigate(from, {replace: true});
+        .then(() => {
+          // navigate user to the page they tried to access before being redirected to login page
+          // navigate(from, {replace: true});
+          navigate('/');
         })
         .catch(err => console.log('error', err));
     }
@@ -50,7 +51,10 @@ export const SignIn = () => {
       const {user, token} = response;
 
       dispatch(setCredentials({user, token}));
-      navigate(from, {replace: true});
+      // navigate user to the page they tried to access before being redirected to login page
+      // navigate(from, {replace: true});
+      // navigate user to home page
+      navigate('/');
     } catch (err) {
       console.log(err);
     }

--- a/app/src/views/SignIn.tsx
+++ b/app/src/views/SignIn.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import {useNavigate, useLocation, Location} from 'react-router-dom';
-import {Typography, Stack, styled, Theme} from '@mui/material';
+import {Typography, Stack, styled, Theme, Link, Box} from '@mui/material';
 
 import {setCredentials} from '../app/authSlice';
 import {useAppDispatch} from '../app/hooks/store';
 import {SignInForm} from '../components/authentication/SignInForm';
 import {SignInRequest, useSignInMutation} from '../services/auth';
-
+import logo from '../img/favicon.png';
 export interface LocationState {
   from: Location;
 }
@@ -62,13 +62,25 @@ export const SignIn = () => {
 
   return (
     <PageContainer>
-      <FormContainer>
+      <FormContainer gap={2}>
+        <Logo src={logo} alt="Home Unite Us logo" />
         <FormHeader variant="h4">Sign in to your account</FormHeader>
         <SignInForm onSubmit={handleSignIn} />
+        <Stack direction="row" alignItems="center" gap={0.5}>
+          <Typography variant="body2">Don&apos;t have an account?</Typography>
+          <Link fontWeight="bold" href="/signup">
+            Sign up
+          </Link>
+        </Stack>
       </FormContainer>
     </PageContainer>
   );
 };
+
+const Logo = styled('img')({
+  width: '100px',
+  height: '100px',
+});
 
 const FormContainer = styled(Stack)(({theme}: {theme: Theme}) => ({
   maxWidth: '550px',
@@ -82,11 +94,10 @@ const FormContainer = styled(Stack)(({theme}: {theme: Theme}) => ({
 
 const FormHeader = styled(Typography)({
   textAlign: 'center',
-  marginBottom: '16px',
   fontWeight: 600,
 });
 
-const PageContainer = styled('div')(({theme}) => ({
+const PageContainer = styled(Box)(({theme}) => ({
   minHeight: '100vh',
   minWidth: '100vw',
   backgroundColor: theme.palette.grey[100],

--- a/app/src/views/SignUp.tsx
+++ b/app/src/views/SignUp.tsx
@@ -30,7 +30,8 @@ export const SignUp = () => {
       })
         .then(res => res.json())
         .then(() => {
-          navigate(from, {replace: true});
+          // navigate(from, {replace: true});
+          navigate('/');
         })
         .catch(err => console.log(err));
     }

--- a/app/src/views/SignUp.tsx
+++ b/app/src/views/SignUp.tsx
@@ -22,7 +22,7 @@ export const SignUp = () => {
   React.useEffect(() => {
     if (location.search.includes('code')) {
       const code = location.search.split('?code=')[1];
-      fetch('/api/auth/token', {
+      fetch('/api/auth/token?callback_uri=http://localhost:4040/signup', {
         headers: {
           'Content-Type': 'application/json',
         },

--- a/app/src/views/SignUp.tsx
+++ b/app/src/views/SignUp.tsx
@@ -7,6 +7,7 @@ import {useAppDispatch} from '../app/hooks/store';
 import {SignUpForm} from '../components/authentication/SignUpForm';
 import {SignUpRequest, useSignUpMutation} from '../services/auth';
 import {LocationState} from './SignIn';
+import logo from '../img/favicon.png';
 
 export const SignUp = () => {
   const navigate = useNavigate();
@@ -54,13 +55,19 @@ export const SignUp = () => {
 
   return (
     <PageContainer>
-      <FormContainer>
+      <FormContainer gap={2}>
+        <Logo src={logo} alt="Home Unite Us logo" />
         <FormHeader variant="h4">Sign up for an account</FormHeader>
         <SignUpForm onSubmit={handleSignUp} />
       </FormContainer>
     </PageContainer>
   );
 };
+
+const Logo = styled('img')({
+  width: '100px',
+  height: '100px',
+});
 
 const PageContainer = styled('div')(({theme}) => ({
   minHeight: '100vh',
@@ -83,6 +90,5 @@ const FormContainer = styled(Stack)(({theme}) => ({
 
 const FormHeader = styled(Typography)({
   textAlign: 'center',
-  marginBottom: '16px',
   fontWeight: 600,
 });


### PR DESCRIPTION
This PR involves changes regarding form links and redirection, such as:

- Creating a global link component in the MUI theme that uses the React Router link component
- Adding a forgot password link and a link to the sign up page if the user needs to create an account
- Adding a HUU logo to the login and sign up pages
- Refactoring the ``/auth/google`` route to accept a redirect uri as a query param since the signup was redirecting the sign in page. I added the same to the ``/auth/token`` route but for a callback uri.