### PR TITLE
Remove Deprecated Dependency

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -9,7 +9,6 @@ clickclick==20.10.2
 colorama==0.4.4
 connexion==2.13.1
 Flask==2.1.2
-greenlet==1.1.2
 idna==3.3
 importlib-metadata==6.0.0
 importlib-resources==5.10.2


### PR DESCRIPTION
## Problem
Unable to install dependencies during setup of application layer.
Ran `pip3 install -r requirements.txt` to get the following message below and not all deps were installed.
![Screenshot 2023-04-24 at 10 32 54 PM](https://user-images.githubusercontent.com/11646566/234463146-a9299690-7abc-426d-9d08-6164cfe34d34.png)

## Solution
Remove `greenlet` dep.

## Things to Consider
- Using a virtualenv.
- Using an M1 MBP. Mentioning this because I had some pathing issues (didn't know brew moved the python packages directory from `/usr/local/bin` to `/opt/homebrew/bin` with the "new" chip).