### PR TITLE
Decouple `service_provider_controller` from db implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 **/.env
 data
 **/.db
+.DS_Store
+.vscode

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -67,3 +67,7 @@ target/
 
 # Local database
 homeuniteus.db
+
+# Local Setup
+.DS_Store
+.vscode

--- a/api/openapi_server/controllers/service_provider_controller.py
+++ b/api/openapi_server/controllers/service_provider_controller.py
@@ -1,15 +1,12 @@
-
+# Third Party
 import connexion
-import six
 import traceback
 
-from openapi_server.models.api_response import ApiResponse  # noqa: E501
+# Local
 from openapi_server.models.service_provider import ServiceProvider  # noqa: E501
-from openapi_server.models.service_provider_with_id import ServiceProviderWithId
-from openapi_server.models import database as db
-from sqlalchemy.orm import Session
+from openapi_server.repositories.service_provider_repository import HousingProviderRepository
 
-db_engine = db.DataAccessLayer.get_engine()
+housing_provider_repository = HousingProviderRepository()
 
 def create_service_provider():  # noqa: E501
     """Create a housing program service provider
@@ -18,26 +15,19 @@ def create_service_provider():  # noqa: E501
 
     :rtype: ServiceProviderWithId
     """
-    if connexion.request.is_json:
-        try:
-            # The auto-generated ServiceProvider provides 
-            # validation of required columns
-            provider = ServiceProvider.from_dict(
-                connexion.request.get_json()).to_dict()  
-        except ValueError:
-            return traceback.format_exc(ValueError), 400
-        with Session(db_engine) as session:
-            row = db.HousingProgramServiceProvider(
-                provider_name=provider["provider_name"]
-            )
-
-            session.add(row)
-            session.commit()
-
-            provider["id"] = row.id
-            return ServiceProviderWithId.from_dict(provider), 201
-    else:
+    if not connexion.request.is_json:
         return "Bad Request", 400
+    
+    try:
+        # The auto-generated ServiceProvider provides 
+        # validation of required columns
+        provider = ServiceProvider.from_dict(
+            connexion.request.get_json()).to_dict()  
+    except ValueError:
+        return traceback.format_exc(ValueError), 400
+    
+    withId = housing_provider_repository.createServiceProvider(provider)
+    return withId, 201
 
 
 def delete_service_provider(provider_id):  # noqa: E501
@@ -50,15 +40,8 @@ def delete_service_provider(provider_id):  # noqa: E501
 
     :rtype: None
     """
-    with Session(db_engine) as session:
-        query = session.query(
-                db.HousingProgramServiceProvider).filter(
-                    db.HousingProgramServiceProvider.id == provider_id)
-        if query.first() != None:
-            query.delete()
-            session.commit()
-            return f"Service Provider with id {provider_id} successfully deleted", 200
-
+    housing_provider_repository.delete_service_provider(provider_id)
+    return f"Service Provider with id {provider_id} successfully deleted", 200
 
 def get_service_provider_by_id(provider_id):  # noqa: E501
     """Get details about a housing program service provider from an ID
@@ -70,37 +53,18 @@ def get_service_provider_by_id(provider_id):  # noqa: E501
 
     :rtype: ServiceProviderWithId
     """
-    with Session(db_engine) as session:
-        row = session.get(
-            db.HousingProgramServiceProvider, provider_id)
-        if row != None:
-            provider = ServiceProvider(
-                provider_name=row.provider_name).to_dict()
-            
-            provider["id"] = row.id
-            return ServiceProviderWithId.from_dict(provider), 200
-        else:
-            return "Not Found", 404
-
+    provider = housing_provider_repository.get_service_provider_by_id(provider_id)
+    return provider, 200 if provider != None else "Not Found", 404
 
 def get_service_providers():  # noqa: E501
     """Get a list of housing program service providers.
 
      # noqa: E501
 
-
     :rtype: List[ServiceProviderWithId]
     """
-    resp = []
-    with Session(db_engine) as session:
-        table = session.query(db.HousingProgramServiceProvider).all()
-        for row in table:
-            provider = ServiceProvider(
-                provider_name=row.provider_name).to_dict()
-            
-            provider["id"] = row.id
-            resp.append(ServiceProviderWithId.from_dict(provider))
-    return resp, 200
+    providers = housing_provider_repository.get_service_providers()
+    return providers, 200
 
 
 def update_service_provider(provider_id):  # noqa: E501
@@ -113,25 +77,16 @@ def update_service_provider(provider_id):  # noqa: E501
 
     :rtype: ServiceProviderWithId
     """
-    if connexion.request.is_json:
-        try:
-            # The auto-generated ServiceProvider provides 
-            # validation of required columns
-            provider = ServiceProvider.from_dict(
-                connexion.request.get_json()).to_dict() 
-        except ValueError:
-            return traceback.format_exc(ValueError), 400
-        with Session(db_engine) as session:
-            query = session.query(
-                db.HousingProgramServiceProvider).filter(
-                    db.HousingProgramServiceProvider.id == provider_id)
-            if query.first() != None:
-                query.update(provider)
-                session.commit()
-                provider["id"] = provider_id
-                return ServiceProviderWithId.from_dict(provider), 200
-            else:
-                return "Not Found", 404
-    else:
+    if not connexion.request.is_json:
         return "Bad Request", 400
-
+    
+    try:
+        # The auto-generated ServiceProvider provides 
+        # validation of required columns
+        provider = ServiceProvider.from_dict(
+            connexion.request.get_json()).to_dict() 
+    except ValueError:
+        return traceback.format_exc(ValueError), 400
+    
+    updated = housing_provider_repository.update_service_provider(provider, provider_id)
+    return updated, 200 if updated != None else "Not Found", 404

--- a/api/openapi_server/repositories/service_provider_repository.py
+++ b/api/openapi_server/repositories/service_provider_repository.py
@@ -1,0 +1,136 @@
+# Third Party
+from sqlalchemy.orm import Session
+
+# Local
+from openapi_server.models.service_provider_with_id import ServiceProviderWithId
+from openapi_server.models.service_provider import ServiceProvider
+from openapi_server.models import database as db
+
+class HousingProviderRepository:
+    
+    def __init__(self, db_engine=db.DataAccessLayer.get_engine()):
+        """Instantiate HousingProviderRepository
+
+        :param db_engine: persistence layer instance
+        :type db_engine: Engine
+
+        :rtype: None
+        """
+        self.db_engine = db_engine
+
+    def create_service_provider(self, provider):
+        """Create a housing program service provider
+
+        :param provider: provider to create. 
+        :type provider: ServiceProvider
+
+        :rtype: ServiceProviderWithId
+        """
+        session = self._get_session()
+        row = self._generate_row(provider)
+
+        session.add(row)
+        session.commit()
+        session.close()
+
+        provider["id"] = row.id
+        return ServiceProviderWithId.from_dict(provider)
+    
+    def delete_service_provider(self, provider_id):
+        """Delete a service provider
+
+        :param provider_id: The ID of the service provider to read, update or delete
+        :type provider_id: int
+
+        :rtype: None
+        """  
+        session = self._get_session()
+        query = self._get_query_by_id(session, provider_id)
+        
+        if query.first() != None:
+            query.delete()
+            session.commit()
+        
+        session.close()
+
+    def get_service_provider_by_id(self, provider_id): 
+        """Get details about a housing program service provider from an ID
+
+        # noqa: E501
+
+        :param provider_id: The ID of the service provider to read, update or delete
+        :type provider_id: int
+
+        :rtype: ServiceProviderWithId
+        """
+        session = self._get_session()
+        result = None
+
+        row = session.get(
+                db.HousingProgramServiceProvider, provider_id)
+        if row != None:
+            provider = ServiceProvider(
+                provider_name=row.provider_name).to_dict()
+            
+            provider["id"] = row.id
+            result = ServiceProviderWithId.from_dict(provider)
+
+        session.close()
+        return result
+            
+    def get_service_providers(self):
+        """Get a list of housing program service providers.
+
+        :rtype: List[ServiceProviderWithId]
+        """
+        providers = []        
+        session = self._get_session()
+        table = session.query(db.HousingProgramServiceProvider).all()
+
+        for row in table:
+            provider = ServiceProvider(
+                provider_name=row.provider_name).to_dict()
+            
+            provider["id"] = row.id
+            providers.append(ServiceProviderWithId.from_dict(provider))
+
+        session.close()
+        return providers
+
+    
+    def update_service_provider(self, provider, provider_id):  
+        """Update a housing program service provider
+
+        :param provider: provider to create. 
+        :type provider: ServiceProvider
+
+        :param provider_id: The ID of the service provider to read, update or delete
+        :type provider_id: int
+
+        :rtype: ServiceProviderWithId
+        """
+        result = None
+        session = self._get_session()
+        query = session.query(
+                db.HousingProgramServiceProvider).filter(
+                    db.HousingProgramServiceProvider.id == provider_id)
+        if query.first() != None:
+            query.update(provider)
+            session.commit()
+            provider["id"] = provider_id
+            result = ServiceProviderWithId.from_dict(provider)
+        session.close()
+        return result
+    
+    def _get_session(self):
+        return Session(self.db_engine)
+    
+    def _generate_row(self, provider):
+        return db.HousingProgramServiceProvider(
+            provider_name=provider["provider_name"]
+        )
+    
+    def _get_query_by_id(self, session, id):
+        return session.query(
+                db.HousingProgramServiceProvider).filter(
+                    db.HousingProgramServiceProvider.id == id)

--- a/api/openapi_server/test/test_service_provider_repository.py
+++ b/api/openapi_server/test/test_service_provider_repository.py
@@ -1,0 +1,168 @@
+# Third Party
+import pytest
+from unittest.mock import MagicMock
+
+# Local
+from openapi_server.models.service_provider import ServiceProvider
+from openapi_server.models.service_provider_with_id import ServiceProviderWithId
+from openapi_server.models import database as db
+from openapi_server.repositories.service_provider_repository import HousingProviderRepository
+
+
+class TestHousingProviderRepository:
+
+    def test_create_provider(self):
+        expected_provider = ServiceProvider("test_name")
+        expected_row = db.HousingProgramServiceProvider(
+            provider_name=expected_provider.to_dict()["provider_name"]
+        )
+        expected_row.id = 1
+        mock_session = MagicMock()
+        repo = HousingProviderRepository(None)
+
+        repo._get_session = lambda: mock_session
+        repo._generate_row = lambda _ : expected_row
+
+        actual = repo.create_service_provider(expected_provider.to_dict())
+
+        assert expected_provider.provider_name == actual.provider_name
+        assert expected_row.id == actual.id
+        mock_session.add.assert_called_with(expected_row)
+        mock_session.commit.assert_called_once()
+        mock_session.close.assert_called_once()
+
+    def test_delete_service_provider_no_result(self):
+        expected_id = 1
+        repo = HousingProviderRepository(None)
+
+        mock_session = MagicMock()
+        mock_query = MagicMock()
+
+        mock_query.first.return_value = None
+        repo._get_session = lambda: mock_session
+        repo._get_query_by_id = lambda x, y: mock_query
+
+        repo.delete_service_provider(expected_id)
+
+        mock_query.first.assert_called_once()
+        mock_query.delete.assert_not_called()
+        mock_session.commit.assert_not_called()
+        mock_session.close.assert_called_once()
+
+    def test_delete_service_provider_some_result(self):
+        expected_id = 1
+        repo = HousingProviderRepository(None)
+        mock_session = MagicMock()
+        mock_query = MagicMock()
+
+        mock_query.first.return_value = True
+        repo._get_session = lambda: mock_session
+        repo._get_query_by_id = lambda x, y: mock_query
+
+        repo.delete_service_provider(expected_id)
+
+        mock_query.first.assert_called_once()
+        mock_query.delete.assert_called_once()
+        mock_session.commit.assert_called_once()
+        mock_session.close.assert_called_once()
+        
+    def test_get_service_provider_by_id_some_result(self):
+        expected_provider = ServiceProvider("test_name")
+        expected_id = 1
+        repo = HousingProviderRepository(None)
+        expected_row = db.HousingProgramServiceProvider(
+            provider_name=expected_provider.to_dict()["provider_name"]
+        )
+        expected_row.id = expected_id
+        mock_session = MagicMock()
+
+        mock_session.get.return_value = expected_row
+        repo._get_session = lambda: mock_session
+
+        actual = repo.get_service_provider_by_id(expected_id)
+
+        assert expected_id == actual.id
+        assert expected_provider.provider_name == actual.provider_name
+        mock_session.close.assert_called_once()
+
+
+    def test_get_service_provider_by_id_no_result(self):
+        repo = HousingProviderRepository(None)
+        expected_row = None
+        mock_session = MagicMock()
+
+        mock_session.get.return_value = expected_row
+        repo._get_session = lambda: mock_session
+
+        actual = repo.get_service_provider_by_id(1)
+
+        assert None == actual
+        mock_session.close.assert_called_once()
+
+    def test_get_service_providers_some_result(self):
+        repo = HousingProviderRepository(None)
+        mock_session = MagicMock()
+        mock_query = MagicMock()
+        provider1 = ServiceProviderWithId(1, "taylor")
+        provider2 = ServiceProviderWithId(2, "swift")
+        expected_providers = [provider1, provider2]
+
+        mock_session.query.return_value = mock_query
+        mock_query.all.return_value = expected_providers
+        repo._get_session = lambda: mock_session
+
+        actual = repo.get_service_providers()
+
+        assert expected_providers == actual
+        mock_session.close.assert_called_once()
+
+    def test_get_service_providers_no_result(self):
+        repo = HousingProviderRepository(None)
+        mock_session = MagicMock()
+
+        repo._get_session = lambda: mock_session
+        mock_session.query.all.return_value = None
+
+        actual = repo.get_service_providers()
+
+        assert [] == actual 
+        mock_session.close.assert_called_once()
+
+    def test_update_service_provider_some_result(self):
+        repo = HousingProviderRepository(None)
+        expected_provider = ServiceProviderWithId(1, "drake")
+        mock_session = MagicMock()
+        mock_result = MagicMock()
+        mock_query = MagicMock()
+
+        repo._get_session = lambda: mock_session
+        mock_session.query.return_value = mock_result
+        mock_result.filter.return_value = mock_query
+        mock_query.first.return_value = True
+
+        actual = repo.update_service_provider(expected_provider.to_dict(), expected_provider.id)
+
+        assert expected_provider == actual
+        mock_query.first.assert_called_once()
+        mock_query.update.assert_called_once_with(expected_provider.to_dict())
+        mock_session.commit.assert_called_once()
+        mock_session.close.assert_called_once()
+
+    def test_update_service_provider_no_result(self):
+        repo = HousingProviderRepository(None)
+        mock_session = MagicMock()
+        mock_result = MagicMock()
+        mock_query = MagicMock()
+
+        repo._get_session = lambda: mock_session
+        mock_session.query.return_value = mock_result
+        mock_result.filter.return_value = mock_query
+        mock_query.first.return_value = None
+
+        actual = repo.update_service_provider({}, 0)
+
+        assert None == actual
+        mock_query.first.assert_called_once()
+        mock_query.update.assert_not_called()
+        mock_session.commit.assert_not_called()
+        mock_session.close.assert_called_once()

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,7 +8,7 @@ click==8.1.3
 clickclick==20.10.2
 colorama==0.4.4
 connexion==2.13.1
-Flask==2.3.2
+Flask==2.2.3
 idna==3.3
 importlib-metadata==6.0.0
 importlib-resources==5.10.2
@@ -33,5 +33,5 @@ SQLAlchemy==1.4.36
 swagger-ui-bundle==0.0.9
 typing_extensions==4.5.0
 urllib3==1.26.9
-Werkzeug==2.2.3
+Werkzeug==2.3.3
 zipp==3.11.0

--- a/api/test-requirements.txt
+++ b/api/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest~=4.6.7 # needed for python 2.7+3.4
-pytest-cov>=2.8.1
-pytest-randomly==1.2.3 # needed for python 2.7+3.4
-Flask-Testing==0.8.0
+pytest==7.3.1
+pytest-cov==4.0.0
+pytest-randomly==3.12.0 
+Flask-Testing==0.8.1


### PR DESCRIPTION
## Problem
Difficult to test controllers. 

Closes #504 

## Solution
- Use `service_provider_controller` as an example.
- Pull out db implementation into "repository" class.
- Add tests.

## Things To Consider
- Live instance of db still coupled to `service_provider_controller`. Hoping to use `Flask-Injector` in a separate PR.
- Need to add test runner to build.