### PR TITLE
Add Initial API Configurator

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -71,3 +71,4 @@ homeuniteus.db
 # Local Setup
 .DS_Store
 .vscode
+personal.py

--- a/api/README.md
+++ b/api/README.md
@@ -132,3 +132,23 @@ docker compose down -v
 ```
 
 This command will stop the containers and delete the volumes. Then you can run `docker compose up api --build` to build and start the containers again.
+
+## Configuration Profile
+For local development, you can create your own set of configurations by doing the following:
+- Add the variable below to your `.env` located in `/api`.
+```
+CONFIG_PROFILE="personal"
+```
+- Create the file `personal.py` at `/api/configs` with the following,
+```
+from configs.configs import Config
+class PersonalConfig(Config):
+    # Example config to override HOST
+    HOST = 8082
+```
+To reference configs in other modules you can do the following if it doesn't exist already,
+```
+from flask import current_app
+current_app.config['CONFIG']
+```
+If you create any new configuration properties, please add an associative enum to `/api/configs/configuration_properties.py`.

--- a/api/configs/config_properties.py
+++ b/api/configs/config_properties.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+class ConfigProperties(Enum):
+    HOST = 'HOST'
+    PORT = 'PORT'
+    DEBUG = 'DEBUG'
+    USE_RELOADER = 'USE_RELOADER'

--- a/api/configs/configs.py
+++ b/api/configs/configs.py
@@ -1,0 +1,32 @@
+import importlib
+
+'''
+**READ ME**
+Never put any sensitive information here i.e. credentials, secrets, etc.
+'''
+
+class Config():
+    HOST = 'localhost'
+    PORT = 8080
+    DEBUG = True
+    USE_RELOADER = True
+
+
+# add class for new configuration profile here
+# i.e. class ProductionConfig(Config) ...
+
+
+def compile_config(profile: str, mod: str = 'configs.personal', clazz: str = 'PersonalConfig') -> Config:
+    config = Config()
+
+    if profile == 'personal':
+        try:
+            personal_mod = importlib.import_module(mod)
+            personal_config = getattr(personal_mod, clazz)
+            config = personal_config
+        except ModuleNotFoundError:
+            raise
+    
+    # handle other profiles here
+
+    return config

--- a/api/configs/personal_config_example.py
+++ b/api/configs/personal_config_example.py
@@ -1,0 +1,11 @@
+from configs.configs import Config
+
+'''
+README:
+- Name your config 'personal.py'
+- Name your class 'PersonalConfig'. And inherit from the Config class i.e. PersonalConfig(Config).
+'''
+class PersonalConfigExample(Config):
+    PORT = 8081
+    DEBUG = False
+    USE_RELOADER = False

--- a/api/openapi_server/__main__.py
+++ b/api/openapi_server/__main__.py
@@ -1,12 +1,18 @@
 #!/usr/bin/env python3
 
-import connexion
+# Standard Lib
 from os import environ as env
+from dotenv import load_dotenv, find_dotenv, get_key
 
+# Third Party
+import connexion
+
+# Local
 from openapi_server import encoder
 from openapi_server.models.database import DataAccessLayer
 from openapi_server.exceptions import AuthError, handle_auth_error
-from dotenv import load_dotenv, find_dotenv
+from configs.configs import compile_config
+from configs.config_properties import ConfigProperties as cp
 
 
 ENV_FILE = find_dotenv()
@@ -16,15 +22,24 @@ SECRET_KEY=env.get('SECRET_KEY')
 
 DataAccessLayer.db_init()
 
-def main():
+def main():    
     app = connexion.App(__name__, specification_dir='./_spec/')
+
+    # Set configs
+    env_config_profile = get_key(find_dotenv(), 'CONFIG_PROFILE')
+    app.app.config.from_object(compile_config(env_config_profile))
     app.app.json_encoder = encoder.JSONEncoder
     app.app.secret_key = SECRET_KEY
     app.add_api('openapi.yaml',
                 arguments={'title': 'Home Unite Us'},
                 pythonic_params=True)             
     app.add_error_handler(AuthError, handle_auth_error)
-    app.run(port=8080, debug=True)
+    app.run(
+        host=app.app.config[cp.HOST.name],
+        port=app.app.config[cp.PORT.name],
+        debug=app.app.config[cp.DEBUG.name],
+        use_reloader=app.app.config[cp.USE_RELOADER.name]
+        )
 
 
 if __name__ == '__main__':

--- a/api/openapi_server/test/test_configs.py
+++ b/api/openapi_server/test/test_configs.py
@@ -1,0 +1,32 @@
+# Third Party
+import pytest
+
+# Local
+from configs.configs import Config, _compile_config
+
+class TestConfigs:
+
+    def test_base_config(self):
+        EXPECTED_NUM_CONFIGS = 4
+
+        configs = Config()
+        config_variables = [ attr for attr in dir(configs) if not callable(getattr(configs, attr)) and not attr.startswith("__") ]
+
+        assert EXPECTED_NUM_CONFIGS == len(config_variables)
+        assert configs.HOST == 'localhost'
+        assert configs.PORT == 8080
+        assert configs.DEBUG == True
+        assert configs.USE_RELOADER == True
+
+    def test_compile_config_no_personal(self):
+        with pytest.raises(ModuleNotFoundError):
+            _compile_config('personal', 'configs.doesnt_exist', 'PersonalConfigExample')
+        
+    def test_compile_config_some_personal(self):
+        configs = _compile_config('personal', 'configs.personal_config_example', 'PersonalConfigExample')
+
+        assert configs.HOST == 'localhost'
+        assert configs.PORT == 8081
+        assert configs.DEBUG == False
+        assert configs.USE_RELOADER == False
+


### PR DESCRIPTION
## Problem
We can't specify dynamic configs at runtime depending on the environment.

closes #522 

## Solution
- Toggle configs via "profiles".
i.e. if you set your CONFIG_PROFILE env variable to 'personal', the following will occur,

**configs.yml**
```
class Config(object):
    HOST = 'localhost'
    PORT = 8080
    DEBUG = True
    USE_RELOADER = True
```
and
**personal.py**
```
class PersonalConfig(Config):
    PORT = 8081
    DEBUG = False
    USE_RELOADER = False
```
then `app.config` will result in,
```
{
    'HOST': 'localhost',
    'PORT': 8081,
    'DEBUG': False,
    'USE_RELOADER': False
}
```
- Add tests.

## Things to Consider
We can now reference the compiled config via,
```
from flask import current_app
current_app.config[< config name >]
```
