### PR TITLE
fix broken host config

### DIFF
--- a/api/configs/configs.py
+++ b/api/configs/configs.py
@@ -6,7 +6,7 @@ Never put any sensitive information here i.e. credentials, secrets, etc.
 '''
 
 class Config():
-    HOST = 'localhost'
+    HOST = '0.0.0.0'
     PORT = 8080
     DEBUG = True
     USE_RELOADER = True

--- a/api/openapi_server/test/test_configs.py
+++ b/api/openapi_server/test/test_configs.py
@@ -2,7 +2,7 @@
 import pytest
 
 # Local
-from configs.configs import Config, _compile_config
+from configs.configs import Config, compile_config
 
 class TestConfigs:
 
@@ -13,19 +13,19 @@ class TestConfigs:
         config_variables = [ attr for attr in dir(configs) if not callable(getattr(configs, attr)) and not attr.startswith("__") ]
 
         assert EXPECTED_NUM_CONFIGS == len(config_variables)
-        assert configs.HOST == 'localhost'
+        assert configs.HOST == '0.0.0.0'
         assert configs.PORT == 8080
         assert configs.DEBUG == True
         assert configs.USE_RELOADER == True
 
     def test_compile_config_no_personal(self):
         with pytest.raises(ModuleNotFoundError):
-            _compile_config('personal', 'configs.doesnt_exist', 'PersonalConfigExample')
+            compile_config('personal', 'configs.doesnt_exist', 'PersonalConfigExample')
         
     def test_compile_config_some_personal(self):
-        configs = _compile_config('personal', 'configs.personal_config_example', 'PersonalConfigExample')
+        configs = compile_config('personal', 'configs.personal_config_example', 'PersonalConfigExample')
 
-        assert configs.HOST == 'localhost'
+        assert configs.HOST == '0.0.0.0'
         assert configs.PORT == 8081
         assert configs.DEBUG == False
         assert configs.USE_RELOADER == False


### PR DESCRIPTION
## Problem
Flask app isn't accessible when started via Docker.

## Solution
- Bind to all server interfaces.
- Fix tests.

## Resources
[listen on all interfaces](https://forums.docker.com/t/docker-is-running-but-i-cannot-access-localhost-flask-application/82193)
[difference between 127.0.0.1 and 0.0.0.0](https://www.baeldung.com/linux/difference-ip-address)