### PR TITLE
Fix API Test Case Failures

### DIFF
--- a/api/openapi_server/controllers/service_provider_controller.py
+++ b/api/openapi_server/controllers/service_provider_controller.py
@@ -42,7 +42,7 @@ def delete_service_provider(provider_id):  # noqa: E501
     """
     if housing_provider_repository.delete_service_provider(provider_id):
         return f"Service Provider with id {provider_id} successfully deleted", 200
-    return f"Service provider {provider_id} not found", '404'
+    return f"Service provider {provider_id} not found", 404
 
 def get_service_provider_by_id(provider_id):  # noqa: E501
     """Get details about a housing program service provider from an ID

--- a/api/openapi_server/controllers/service_provider_controller.py
+++ b/api/openapi_server/controllers/service_provider_controller.py
@@ -26,7 +26,7 @@ def create_service_provider():  # noqa: E501
     except ValueError:
         return traceback.format_exc(ValueError), 400
     
-    withId = housing_provider_repository.createServiceProvider(provider)
+    withId = housing_provider_repository.create_service_provider(provider)
     return withId, 201
 
 

--- a/api/openapi_server/controllers/service_provider_controller.py
+++ b/api/openapi_server/controllers/service_provider_controller.py
@@ -54,7 +54,7 @@ def get_service_provider_by_id(provider_id):  # noqa: E501
     :rtype: ServiceProviderWithId
     """
     provider = housing_provider_repository.get_service_provider_by_id(provider_id)
-    return provider, 200 if provider != None else "Not Found", 404
+    return (provider, 200) if provider is not None else ("Not Found", 404)
 
 def get_service_providers():  # noqa: E501
     """Get a list of housing program service providers.
@@ -89,4 +89,4 @@ def update_service_provider(provider_id):  # noqa: E501
         return traceback.format_exc(ValueError), 400
     
     updated = housing_provider_repository.update_service_provider(provider, provider_id)
-    return updated, 200 if updated != None else "Not Found", 404
+    return (updated, 200) if updated is not None else ("Not Found", 404)

--- a/api/openapi_server/controllers/service_provider_controller.py
+++ b/api/openapi_server/controllers/service_provider_controller.py
@@ -40,8 +40,9 @@ def delete_service_provider(provider_id):  # noqa: E501
 
     :rtype: None
     """
-    housing_provider_repository.delete_service_provider(provider_id)
-    return f"Service Provider with id {provider_id} successfully deleted", 200
+    if housing_provider_repository.delete_service_provider(provider_id):
+        return f"Service Provider with id {provider_id} successfully deleted", 200
+    return f"Service provider {provider_id} not found", '404'
 
 def get_service_provider_by_id(provider_id):  # noqa: E501
     """Get details about a housing program service provider from an ID

--- a/api/openapi_server/repositories/service_provider_repository.py
+++ b/api/openapi_server/repositories/service_provider_repository.py
@@ -8,7 +8,7 @@ from openapi_server.models import database as db
 
 class HousingProviderRepository:
     
-    def __init__(self, db_engine=db.DataAccessLayer.get_engine()):
+    def __init__(self, db_engine=None):
         """Instantiate HousingProviderRepository
 
         :param db_engine: persistence layer instance
@@ -16,6 +16,8 @@ class HousingProviderRepository:
 
         :rtype: None
         """
+        if db_engine is None:
+            db_engine = db.DataAccessLayer.get_engine()
         self.db_engine = db_engine
 
     def create_service_provider(self, provider):

--- a/api/openapi_server/repositories/service_provider_repository.py
+++ b/api/openapi_server/repositories/service_provider_repository.py
@@ -37,21 +37,23 @@ class HousingProviderRepository:
         return ServiceProviderWithId.from_dict(provider)
     
     def delete_service_provider(self, provider_id):
-        """Delete a service provider
+        """Delete a service provider. Return false if the
+        service provider is not found. Return true otherwise.
 
         :param provider_id: The ID of the service provider to read, update or delete
         :type provider_id: int
 
-        :rtype: None
+        :rtype: bool
         """  
+        num_rows_deleted = 0
         session = self._get_session()
         query = self._get_query_by_id(session, provider_id)
-        
         if query.first() != None:
-            query.delete()
+            num_rows_deleted = query.delete()
             session.commit()
         
         session.close()
+        return bool(num_rows_deleted > 0)
 
     def get_service_provider_by_id(self, provider_id): 
         """Get details about a housing program service provider from an ID

--- a/api/openapi_server/repositories/service_provider_repository.py
+++ b/api/openapi_server/repositories/service_provider_repository.py
@@ -31,9 +31,9 @@ class HousingProviderRepository:
 
         session.add(row)
         session.commit()
-        session.close()
-
         provider["id"] = row.id
+
+        session.close()
         return ServiceProviderWithId.from_dict(provider)
     
     def delete_service_provider(self, provider_id):

--- a/api/openapi_server/test/__init__.py
+++ b/api/openapi_server/test/__init__.py
@@ -10,7 +10,7 @@ class BaseTestCase(TestCase):
 
     def create_app(self):
         logging.getLogger('connexion.operation').setLevel('ERROR')
-        app = connexion.App(__name__, specification_dir='../openapi/')
+        app = connexion.App(__name__, specification_dir='../_spec/')
         app.app.json_encoder = JSONEncoder
         app.add_api('openapi.yaml', pythonic_params=True)
         return app.app

--- a/api/openapi_server/test/__init__.py
+++ b/api/openapi_server/test/__init__.py
@@ -1,16 +1,44 @@
 import logging
+from pathlib import Path
 
 import connexion
 from flask_testing import TestCase
 
 from openapi_server.encoder import JSONEncoder
+from openapi_server.models import database
 
 
 class BaseTestCase(TestCase):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.cached_engine = None
+        self.tmp_testing_database = Path("testinghomeuniteus.db")
+        
+
     def create_app(self):
+        '''
+        Create a temporary, empty database for testing purposes and setup
+        a new instance of our Flask App for testing purposes.
+        '''
+        # Cache a reference to the current engine, so we can restore the previous
+        # DataAccessLayer once our test is complete
+        self.cached_engine = database.DataAccessLayer._engine
+
+        database.DataAccessLayer._engine = None 
+        database.DataAccessLayer.get_engine(f"sqlite:///./{self.tmp_testing_database}")
+        database.DataAccessLayer.db_init()
+
         logging.getLogger('connexion.operation').setLevel('ERROR')
         app = connexion.App(__name__, specification_dir='../_spec/')
         app.app.json_encoder = JSONEncoder
         app.add_api('openapi.yaml', pythonic_params=True)
         return app.app
+    
+    def tearDown(self):
+        '''
+        Delete our temporary testing database and restore the DataAccessLayer
+        to its state before our test case ran.
+        '''
+        database.DataAccessLayer._engine = self.cached_engine
+        self.tmp_testing_database.unlink(missing_ok=True)

--- a/api/openapi_server/test/test_configs.py
+++ b/api/openapi_server/test/test_configs.py
@@ -2,7 +2,7 @@
 import pytest
 
 # Local
-from configs.configs import Config, _compile_config
+from configs.configs import Config, compile_config
 
 class TestConfigs:
 
@@ -20,10 +20,10 @@ class TestConfigs:
 
     def test_compile_config_no_personal(self):
         with pytest.raises(ModuleNotFoundError):
-            _compile_config('personal', 'configs.doesnt_exist', 'PersonalConfigExample')
+            compile_config('personal', 'configs.doesnt_exist', 'PersonalConfigExample')
         
     def test_compile_config_some_personal(self):
-        configs = _compile_config('personal', 'configs.personal_config_example', 'PersonalConfigExample')
+        configs = compile_config('personal', 'configs.personal_config_example', 'PersonalConfigExample')
 
         assert configs.HOST == 'localhost'
         assert configs.PORT == 8081

--- a/api/openapi_server/test/test_service_provider_controller.py
+++ b/api/openapi_server/test/test_service_provider_controller.py
@@ -18,19 +18,7 @@ class TestServiceProviderController(BaseTestCase):
 
         Create a housing program service provider
         """
-        housing_program_service_provider = {
-  "provider_name" : "provider_name"
-}
-        headers = { 
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
-        }
-        response = self.client.open(
-            '/api/serviceProviders',
-            method='POST',
-            headers=headers,
-            data=json.dumps(housing_program_service_provider),
-            content_type='application/json')
+        response = self.create_service_provider()
         self.assertStatus(response, 201,
                        'Response body is : ' + response.data.decode('utf-8'))
 
@@ -39,11 +27,13 @@ class TestServiceProviderController(BaseTestCase):
 
         Delete a service provider
         """
+        # Test database is empty at start. Create an entry to delete
+        ids = self.populate_test_database(num_entries=1)
         headers = { 
             'Accept': 'application/json',
         }
         response = self.client.open(
-            '/api/serviceProviders/{provider_id}'.format(provider_id=56),
+            f'/api/serviceProviders/{ids[0]}',
             method='DELETE',
             headers=headers)
         self.assert200(response,
@@ -54,11 +44,12 @@ class TestServiceProviderController(BaseTestCase):
 
         Get details about a housing program service provider from an ID
         """
+        ids = self.populate_test_database(num_entries=8)
         headers = { 
             'Accept': 'application/json',
         }
         response = self.client.open(
-            '/api/serviceProviders/{provider_id}'.format(provider_id=56),
+            f"/api/serviceProviders/{ids[3]}",
             method='GET',
             headers=headers)
         self.assert200(response,
@@ -69,6 +60,9 @@ class TestServiceProviderController(BaseTestCase):
 
         Get a list of housing program service providers.
         """
+        expected_provider_count = 12
+        self.populate_test_database(num_entries=expected_provider_count)
+        
         headers = { 
             'Accept': 'application/json',
         }
@@ -76,14 +70,18 @@ class TestServiceProviderController(BaseTestCase):
             '/api/serviceProviders',
             method='GET',
             headers=headers)
+        response_str = response.data.decode('utf-8')  
         self.assert200(response,
-                       'Response body is : ' + response.data.decode('utf-8'))
+                       f"Response body is : {response_str}")
+        decoded_response = json.loads(response_str)
+        assert len(decoded_response) == expected_provider_count
 
     def test_update_service_provider(self):
         """Test case for update_service_provider
 
         Update a housing program service provider
         """
+        ids = self.populate_test_database(num_entries=1)
         housing_program_service_provider = {
   "provider_name" : "provider_name"
 }
@@ -92,7 +90,7 @@ class TestServiceProviderController(BaseTestCase):
             'Content-Type': 'application/json',
         }
         response = self.client.open(
-            '/api/serviceProviders/{provider_id}'.format(provider_id=56),
+            f"/api/serviceProviders/{ids[0]}",
             method='PUT',
             headers=headers,
             data=json.dumps(housing_program_service_provider),

--- a/api/openapi_server/test/test_service_provider_controller.py
+++ b/api/openapi_server/test/test_service_provider_controller.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 
 from __future__ import absolute_import
-import unittest
 
 from flask import json
 from six import BytesIO
@@ -100,7 +99,3 @@ class TestServiceProviderController(BaseTestCase):
             content_type='application/json')
         self.assert200(response,
                        'Response body is : ' + response.data.decode('utf-8'))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/api/openapi_server/test/test_service_provider_repository.py
+++ b/api/openapi_server/test/test_service_provider_repository.py
@@ -39,11 +39,13 @@ class TestHousingProviderRepository:
         mock_query = MagicMock()
 
         mock_query.first.return_value = None
+        mock_query.delete.return_value = 0
         repo._get_session = lambda: mock_session
         repo._get_query_by_id = lambda x, y: mock_query
 
-        repo.delete_service_provider(expected_id)
-
+        row_deleted = repo.delete_service_provider(expected_id)
+        
+        assert row_deleted == False
         mock_query.first.assert_called_once()
         mock_query.delete.assert_not_called()
         mock_session.commit.assert_not_called()
@@ -56,11 +58,13 @@ class TestHousingProviderRepository:
         mock_query = MagicMock()
 
         mock_query.first.return_value = True
+        mock_query.delete.return_value = 1
         repo._get_session = lambda: mock_session
         repo._get_query_by_id = lambda x, y: mock_query
 
-        repo.delete_service_provider(expected_id)
+        row_deleted = repo.delete_service_provider(expected_id)
 
+        assert row_deleted == True
         mock_query.first.assert_called_once()
         mock_query.delete.assert_called_once()
         mock_session.commit.assert_called_once()

--- a/api/openapi_server/test/test_service_provider_repository.py
+++ b/api/openapi_server/test/test_service_provider_repository.py
@@ -1,5 +1,4 @@
 # Third Party
-import pytest
 from unittest.mock import MagicMock
 
 # Local
@@ -7,7 +6,6 @@ from openapi_server.models.service_provider import ServiceProvider
 from openapi_server.models.service_provider_with_id import ServiceProviderWithId
 from openapi_server.models import database as db
 from openapi_server.repositories.service_provider_repository import HousingProviderRepository
-
 
 class TestHousingProviderRepository:
 


### PR DESCRIPTION
The API test cases are failing with this error: `jsonschema.exceptions.RefResolutionError: unknown url type: './paths/users.yaml'`.

The root cause of this failure was in `BastTestCase.create_app`. There is a known issue related to the application specification in 
#539. The specification file cannot contain references to other files, so our flask app should use the `openapi_server/_spec/openapi.yaml` file. The test app, however, was using the `openapi_server/openapi/openapi.yaml` file instead.

Unfortunately, when I made this fix I found several other failing test cases and some other sources of testing errors. This PR contains the minimum fixes needed to get the test cases passing again. I refrained from making any design changes at this point.

Here are a summary of the fixes:
* Fix an `AttributeError` in `service_provider_controller.py`'s `create_service_provider()` method. The test cases were failing with a status code of `500` since an unhandled exception was being thrown here
* Fix `Instance not bound to session` err that was being thrown while creating a service provider. Test cases were failing with a status code of `500` here too.
  * The database row id was being read after calling `session.close()`. This is not a problem if the session has been flushed, but by default SQLAlchemy will lazily load the row, so attempting to read after closing the session can cause an error. To fix I just read the row id before closing.
* Fix return syntax error in `get_service_provider_by_id` and `update_service_provider`. These methods were not returning the correct status code if the provider search failed
* Add an error status code to `delete_service_provider` if the provider deletion fails. Our test cases were passing, even though no deletion was occuring, since we were always passing back a successful status code
* Update the controller test cases to use a temporary testing database. Previously the test cases were operating on the host's local database. This means that the tests would only pass if the host happened to have a database with a sufficient number of entries. The new test setup has the added benefit of making the controller test cases independent of each other.
  * Note: Our Flask app interface does not allow the ability to specify a custom database, so I had to hack it a bit. Ideally we'd redesign our interface with testing in mind - but I wanted to limit the scope of this issue 
* Fix syntax error in `HousingProviderRepository.__init__`. Default args are only evaluated when the method definition is executed, so move the call to `get_engine` into the method body. 
* remove `test_match_filtering.py`. This file was empty and unused