### PR TITLE
Fix dropdown menu bug

### DIFF
--- a/app/src/components/common/Header.tsx
+++ b/app/src/components/common/Header.tsx
@@ -47,35 +47,11 @@ const navItems = [
 export const Header = (props: Props) => {
   const {window} = props;
   const [mobileOpen, setMobileOpen] = React.useState(false);
-  const [anchorElUser, setAnchorElUser] = React.useState<null | HTMLElement>(
-    null,
-  );
 
   const {user} = useAuth();
-  const [signOut] = useSignOutMutation();
-  const appDispatch = useAppDispatch();
-  const navigate = useNavigate();
-
-  const handleSignOut = async () => {
-    try {
-      await signOut().unwrap();
-      appDispatch(setCredentials({user: null, token: null}));
-      navigate('/signin');
-    } catch (err) {
-      console.log(err);
-    }
-  };
 
   const handleDrawerToggle = () => {
     setMobileOpen(prevState => !prevState);
-  };
-
-  const handleOpenUserMenu = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorElUser(event.currentTarget);
-  };
-
-  const handleCloseUserMenu = () => {
-    setAnchorElUser(null);
   };
 
   const drawer = (
@@ -137,46 +113,7 @@ export const Header = (props: Props) => {
                 })}
               </Box>
             ) : null}
-            {user ? (
-              <Box sx={{flexGrow: 0}}>
-                <Tooltip title="Open settings">
-                  <IconButton onClick={handleOpenUserMenu} sx={{p: 0}}>
-                    {/* Replace with real user name */}
-                    <Avatar alt={userName}>{getInitials(userName)}</Avatar>
-                  </IconButton>
-                </Tooltip>
-                <Menu
-                  sx={{mt: '45px'}}
-                  id="menu-appbar"
-                  anchorEl={anchorElUser}
-                  anchorOrigin={{
-                    vertical: 'top',
-                    horizontal: 'right',
-                  }}
-                  keepMounted
-                  transformOrigin={{
-                    vertical: 'top',
-                    horizontal: 'right',
-                  }}
-                  open={Boolean(anchorElUser)}
-                  onClose={handleCloseUserMenu}
-                >
-                  <MenuItem component={Link} to="/settings">
-                    <Typography textAlign="center">Settings</Typography>
-                  </MenuItem>
-                  <MenuItem
-                    component="a"
-                    target="_blank"
-                    href="https://github.com/hackforla/HomeUniteUs/wiki/Home-Unite-Us-User-Guide"
-                  >
-                    <Typography textAlign="center">Help</Typography>
-                  </MenuItem>
-                  <MenuItem onClick={handleSignOut}>
-                    <Typography textAlign="center">Logout</Typography>
-                  </MenuItem>
-                </Menu>
-              </Box>
-            ) : null}
+            {user ? <AvatarDropdownMenu /> : null}
           </Stack>
         </Toolbar>
       </AppBar>
@@ -197,6 +134,75 @@ export const Header = (props: Props) => {
           {drawer}
         </Drawer>
       </Box>
+    </Box>
+  );
+};
+
+const AvatarDropdownMenu = () => {
+  const [signOut] = useSignOutMutation();
+  const appDispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const [anchorElUser, setAnchorElUser] = React.useState<null | HTMLElement>(
+    null,
+  );
+
+  const handleSignOut = async () => {
+    try {
+      await signOut().unwrap();
+      appDispatch(setCredentials({user: null, token: null}));
+      navigate('/signin');
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  const handleOpenUserMenu = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorElUser(event.currentTarget);
+  };
+
+  const handleCloseUserMenu = () => {
+    setAnchorElUser(null);
+  };
+
+  return (
+    <Box sx={{flexGrow: 0}}>
+      <Tooltip title="Open settings">
+        <IconButton onClick={handleOpenUserMenu} sx={{p: 0}}>
+          {/* Replace with real user name */}
+          <Avatar alt={userName}>{getInitials(userName)}</Avatar>
+        </IconButton>
+      </Tooltip>
+      <Menu
+        sx={{mt: '45px'}}
+        id="menu-appbar"
+        anchorEl={anchorElUser}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        keepMounted
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        open={Boolean(anchorElUser)}
+        onClose={handleCloseUserMenu}
+      >
+        <MenuItem component={Link} to="/settings">
+          <Typography textAlign="center">Settings</Typography>
+        </MenuItem>
+        <MenuItem
+          component="a"
+          target="_blank"
+          href="https://github.com/hackforla/HomeUniteUs/wiki/Home-Unite-Us-User-Guide"
+        >
+          <Typography textAlign="center">Help</Typography>
+        </MenuItem>
+        <MenuItem onClick={handleSignOut}>
+          <Typography textAlign="center">Logout</Typography>
+        </MenuItem>
+      </Menu>
     </Box>
   );
 };


### PR DESCRIPTION
Fixes [549](https://github.com/hackforla/HomeUniteUs/issues/549)

The issue came from setting the anchor element for the menu as the avatar, but then removing the element when the user logs out and not clearing the state. One approach would have been to reset the state when logging out, but I felt it made sense to break this into it's own component so it can handle it's own state.