### PR TITLE
Confirm signup page

### DIFF
--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -37,6 +37,7 @@ import {
   ForgotPasswordCode,
   ForgotPasswordSuccess,
   Settings,
+  ConfirmSignUp,
 } from './views';
 import {AccountVerification} from './views/AccountVerification';
 import {AppLayout, Header} from './components/common';
@@ -96,6 +97,7 @@ function HuuApp() {
           />
           <Route path="/signin" element={<SignIn />} />
           <Route path="/signup" element={<SignUp />} />
+          <Route path="/signup/success" element={<ConfirmSignUp />} />
           <Route path="/forgot-password" element={<ResetPasswordContext />}>
             <Route index element={<ForgotPassword />} />
             <Route path="code" element={<ForgotPasswordCode />} />

--- a/app/src/services/auth.ts
+++ b/app/src/services/auth.ts
@@ -64,6 +64,15 @@ export interface TokenResponse {
   user: User;
 }
 
+export interface ResendConfirmationCodeRequest {
+  email: string;
+}
+
+export interface ResendConfirmationCodeResponse {
+  message: string;
+}
+// /auth/resend_confirmation_code
+
 const authApi = api.injectEndpoints({
   endpoints: build => ({
     signUpHost: build.mutation<SignUpHostResponse, SignUpHostRequest>({
@@ -170,6 +179,20 @@ const authApi = api.injectEndpoints({
         withCredentials: true,
       }),
     }),
+    resendConfirmationCode: build.mutation<
+      ResendConfirmationCodeResponse,
+      ResendConfirmationCodeRequest
+    >({
+      query: body => ({
+        url: 'auth/resend_confirmation_code',
+        method: 'POST',
+        headers: {
+          'Access-Control-Allow-Origin': 'http://localhost:4040',
+        },
+        body,
+        withCredentials: true,
+      }),
+    }),
   }),
   overrideExisting: false,
 });
@@ -187,4 +210,5 @@ export const {
   useSessionMutation,
   useUserQuery,
   usePrivateQuery,
+  useResendConfirmationCodeMutation,
 } = authApi;

--- a/app/src/views/ConfirmSignUp.tsx
+++ b/app/src/views/ConfirmSignUp.tsx
@@ -1,8 +1,52 @@
 import React from 'react';
+import {
+  Typography,
+  Stack,
+  Button,
+  CircularProgress,
+  IconButton,
+  Alert,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import {useSearchParams} from 'react-router-dom';
+import {useResendConfirmationCodeMutation} from '../services/auth';
 import {FormContainer} from '../components/authentication';
-import {Typography, Stack, Button} from '@mui/material';
+import {isFetchBaseQueryError, isErrorWithMessage} from '../app/helpers';
+
+interface Alert {
+  severity: 'success' | 'error';
+  message: string;
+}
 
 export const ConfirmSignUp = () => {
+  const [alert, setAlert] = React.useState<Alert | undefined>(undefined);
+  const [resendCode, {isLoading}] = useResendConfirmationCodeMutation();
+  const [searchParams] = useSearchParams();
+  const email = searchParams.get('email');
+
+  const handleResendCode = async () => {
+    if (!email) return;
+
+    try {
+      await resendCode({email}).unwrap();
+      setAlert({
+        severity: 'success',
+        message: 'A new verification link has been sent to your email.',
+      });
+    } catch (err) {
+      let errorMessage = '';
+      if (isFetchBaseQueryError(err)) {
+        errorMessage = err.data.message;
+      } else if (isErrorWithMessage(err)) {
+        errorMessage = err.message;
+      }
+      setAlert({
+        severity: 'error',
+        message: errorMessage,
+      });
+    }
+  };
+
   return (
     <FormContainer>
       <Stack
@@ -10,15 +54,44 @@ export const ConfirmSignUp = () => {
         spacing={4}
         sx={{justifyContent: 'center', alignItems: 'center', width: '100%'}}
       >
+        {alert ? (
+          <Alert
+            sx={{width: '100%'}}
+            severity={alert.severity}
+            action={
+              <IconButton
+                aria-label="close"
+                color="inherit"
+                size="small"
+                onClick={() => {
+                  setAlert(undefined);
+                }}
+              >
+                <CloseIcon fontSize="inherit" />
+              </IconButton>
+            }
+          >
+            {alert.message}
+          </Alert>
+        ) : null}
         <Typography variant="h4" fontWeight="600" textAlign="center">
           Confirm your email address
         </Typography>
         <Typography variant="body1" textAlign="center">
-          We sent a verification link to <strong>sample@email.com</strong>.
-          Please follow the instructions in the email to complete registration.
+          We sent a verification link to <strong>{email}</strong>. Please follow
+          the instructions in the email to complete registration.
         </Typography>
-        <Button fullWidth variant="contained" size="large" type="submit">
+        <Button
+          fullWidth
+          variant="contained"
+          size="large"
+          onClick={handleResendCode}
+          disabled={isLoading}
+        >
           Resend email
+          {isLoading ? (
+            <CircularProgress sx={{mx: 1}} size={20} color="inherit" />
+          ) : null}
         </Button>
         <Button href="/forgot-password" fullWidth variant="outlined">
           Back

--- a/app/src/views/ConfirmSignUp.tsx
+++ b/app/src/views/ConfirmSignUp.tsx
@@ -86,14 +86,14 @@ export const ConfirmSignUp = () => {
           variant="contained"
           size="large"
           onClick={handleResendCode}
-          disabled={isLoading}
+          disabled={isLoading || !email}
         >
           Resend email
           {isLoading ? (
             <CircularProgress sx={{mx: 1}} size={20} color="inherit" />
           ) : null}
         </Button>
-        <Button href="/forgot-password" fullWidth variant="outlined">
+        <Button href="/signup" fullWidth variant="outlined">
           Back
         </Button>
       </Stack>

--- a/app/src/views/ConfirmSignUp.tsx
+++ b/app/src/views/ConfirmSignUp.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import {FormContainer} from '../components/authentication';
+import {Typography, Stack, Button} from '@mui/material';
+
+export const ConfirmSignUp = () => {
+  return (
+    <FormContainer>
+      <Stack
+        py={2}
+        spacing={4}
+        sx={{justifyContent: 'center', alignItems: 'center', width: '100%'}}
+      >
+        <Typography variant="h4" fontWeight="600" textAlign="center">
+          Confirm your email address
+        </Typography>
+        <Typography variant="body1" textAlign="center">
+          We sent a verification link to <strong>sample@email.com</strong>.
+          Please follow the instructions in the email to complete registration.
+        </Typography>
+        <Button fullWidth variant="contained" size="large" type="submit">
+          Resend email
+        </Button>
+        <Button href="/forgot-password" fullWidth variant="outlined">
+          Back
+        </Button>
+      </Stack>
+    </FormContainer>
+  );
+};

--- a/app/src/views/index.ts
+++ b/app/src/views/index.ts
@@ -14,3 +14,4 @@ export {NewPassword} from './NewPassword';
 export {ForgotPasswordCode} from './ForgotPasswordCode';
 export {ForgotPasswordSuccess} from './ForgotPasswordSuccess';
 export {Settings} from './Settings';
+export {ConfirmSignUp} from './ConfirmSignUp';


### PR DESCRIPTION
This PR adds the confirm sign up page where the user is redirected after successfully signing up and includes:

- A sign up success page
- A resend email button that resends the verification email
- A back button that takes the user back to the sign up page
- Success and error handling as well loading states

<img width="1436" alt="Screenshot 2023-08-01 at 4 01 07 PM" src="https://github.com/hackforla/HomeUniteUs/assets/27253583/4f8275a8-db2f-4ef4-abef-04e4448a906c">
