### PR TITLE
Update connexion to 2.14.2, pytest to 7.4.2, and downgrade werkzeug to 2.2.3

### DIFF
--- a/api/openapi_server/__main__.py
+++ b/api/openapi_server/__main__.py
@@ -9,7 +9,6 @@ from dotenv import load_dotenv, find_dotenv, get_key
 import prance
 
 # Local
-from openapi_server import encoder
 from openapi_server.models.database import DataAccessLayer
 from openapi_server.exceptions import AuthError, handle_auth_error
 from configs.configs import compile_config
@@ -81,7 +80,6 @@ def create_app():
     # The underlying instance of Flask is stored in `connexion_app.app`.
     # This is an instance of `flask.Flask`.
     flask_app = connexion_app.app
-    flask_app.json_encoder = encoder.JSONEncoder
     flask_app.secret_key = SECRET_KEY
 
     # Below, the Flask configuration handler is loaded with the

--- a/api/openapi_server/encoder.py
+++ b/api/openapi_server/encoder.py
@@ -1,7 +1,0 @@
-from connexion.apps.flask_app import FlaskJSONEncoder
-
-class JSONEncoder(FlaskJSONEncoder):
-    include_nulls = False
-
-    def default(self, o):
-        return FlaskJSONEncoder.default(self, o)

--- a/api/openapi_server/test/__init__.py
+++ b/api/openapi_server/test/__init__.py
@@ -5,7 +5,6 @@ import connexion
 from flask_testing import TestCase
 from typing import List
 
-from openapi_server.encoder import JSONEncoder
 from openapi_server.models.database import DataAccessLayer
 from openapi_server.__main__ import get_bundled_specs
 from openapi_server.repositories.service_provider_repository import HousingProviderRepository
@@ -33,7 +32,6 @@ class BaseTestCase(TestCase):
 
         logging.getLogger('connexion.operation').setLevel('ERROR')
         app = connexion.App(__name__)
-        app.app.json_encoder = JSONEncoder
         app.add_api(get_bundled_specs(Path('openapi_server/openapi/openapi.yaml')),
                 pythonic_params=True)   
         return app.app      

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     # connexion implements routing, validation, security, and parameter passing based on the
     # OpenAPI specification that is defined in the `openapi_server/openapi` directory.
     # The extra dependency swagger-ui causes the swagger UI to be available at /api/ui.
-    "connexion [swagger-ui]==2.13.1",
+    "connexion [swagger-ui]==2.14.2",
 
     # psycopg2 allows SQLAlchemy to communicate with PostgreSQL
     "psycopg2-binary==2.9.5",
@@ -121,7 +121,7 @@ dev = [
   "tox==4.6.4",
 
   # pytest runs the tests implemented in this project.
-  "pytest==7.3.1",
+  "pytest==7.4.2",
 
   # pytest-cov will report the amount of test coverage implemented.
   "pytest-cov==4.0.0",

--- a/api/requirements-dev.txt
+++ b/api/requirements-dev.txt
@@ -36,12 +36,8 @@ click==8.1.7
 clickclick==20.10.2
     # via connexion
 colorama==0.4.6
-    # via
-    #   build
-    #   click
-    #   pytest
-    #   tox
-connexion==2.13.1
+    # via tox
+connexion==2.14.2
     # via homeuniteus-api (pyproject.toml)
 coverage==7.3.0
     # via pytest-cov
@@ -134,7 +130,7 @@ pyproject-api==1.5.4
     # via tox
 pyproject-hooks==1.0.0
     # via build
-pytest==7.3.1
+pytest==7.4.2
     # via
     #   homeuniteus-api (pyproject.toml)
     #   pytest-cov
@@ -204,7 +200,7 @@ urllib3==1.26.16
     #   requests
 virtualenv==20.24.3
     # via tox
-werkzeug==2.3.7
+werkzeug==2.2.3
     # via
     #   connexion
     #   flask

--- a/api/requirements-dev.txt
+++ b/api/requirements-dev.txt
@@ -36,7 +36,11 @@ click==8.1.7
 clickclick==20.10.2
     # via connexion
 colorama==0.4.6
-    # via tox
+    # via 
+    #   build
+    #   click
+    #   pytest
+    #   tox
 connexion==2.14.2
     # via homeuniteus-api (pyproject.toml)
 coverage==7.3.0

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -28,7 +28,7 @@ click==8.1.7
     #   flask
 clickclick==20.10.2
     # via connexion
-connexion==2.13.1
+connexion==2.14.2
     # via homeuniteus-api (pyproject.toml)
 flask==2.2.5
     # via connexion
@@ -135,7 +135,7 @@ urllib3==1.26.16
     # via
     #   botocore
     #   requests
-werkzeug==2.3.7
+werkzeug==2.2.3
     # via
     #   connexion
     #   flask


### PR DESCRIPTION
Closes https://github.com/hackforla/HomeUniteUs/issues/580

What changes did you make?
This PR includes the following changes:

· Removes the encoder.py file from the openapi_server directory and removes the encoder use in main, and init test files to eliminate test errors.
· Updates version of Connexion from 2.13.1 to 2.14.2
· Updates pytest from 7.3.1 to 7.4.2
· Downgrades Werkzeug from 2.3.7 to 2.2.3 to remove dependency conflicts

Rationale behind the changes?
The rationale behind these changes was to update Connexion and Flask to newer versions and to remove the deprecation warning the team was receiving when starting the virtual environment and running the test suite. Flask version 2.2.5 was unable to be updated due to conflicts with dependencies required for Connexion. Flask will have to wait to be updated until Connexion version 3.0 is released. The Werkzeug version had to be downgraded because Connexion version 2.14.2 requires version < 2.3 while the older version was compatible with 2.3.7.

 Pytest was updated because there were no breaking changes between versions according to the change logs, this version is still compatible with python 3.7+

https://docs.pytest.org/en/7.4.x/changelog.html

Testing done for these changes:
To confirm the test suite still passes, tests were run in the virtual environment in which 27 test cases passed.

What did you learn or can share that is new?(optional)
I learned through the process that when updating to later versions, it's important to check if there are any coexisting dependencies that require versions which are incompatible with each other.

Since this is my first PR please let me know if any additional information is needed for documentation.