### PR TITLE
Update build-deploy-ec2.yml

### DIFF
--- a/.github/workflows/build-deploy-ec2.yml
+++ b/.github/workflows/build-deploy-ec2.yml
@@ -2,6 +2,12 @@ name: Build and Deploy to EC2
 # workflow_dispatch means this workflow is manually triggered.
 # The user will select the branch or tag from the GitHub UI to run this workflow against.
 on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: 
+      - main
   workflow_dispatch:
 jobs:
   run-tests:
@@ -75,6 +81,8 @@ jobs:
   deploy-api-app:
     needs: [build-api, build-app]
     runs-on: ubuntu-latest
+    # Only one deployment job should run at a time because it updates the EC2 instance destructively
+    concurrency: deploy-one-at-a-time
     steps:
       - name: Download all workflow run artifacts
         uses: actions/download-artifact@v3


### PR DESCRIPTION
Automatically build and deploy code that reaches the main branch. Allow only one deployment job to run at a time because there are no other synchronization mechanisms in place.


### What changes did you make?
  - Changed the build-deploy-ec2 workflow so that it runs on merge to main and PR to main as the target.
  
### Rationale behind the changes?
  - The api and app tests are now running on commits, merge to main, PR targeting the main branch. This gives some assurance that code can be deployed to the dev environment automatically without manual intervention. The caveat is when there are environment variable updates then the EC2 instance will need to be updated and the code manually deployed.
  
### Testing done for these changes
  - Can't test until it reaches the main branch.

### What did you learn or can share that is new?(optional)
  - GitHub workflows have concurrency controls to allow one workflow or job to run and one pending.