### PR TITLE
Add required asterisk to intake form

### DIFF
--- a/app/src/components/intake-profile/IntakeProfileGroups.tsx
+++ b/app/src/components/intake-profile/IntakeProfileGroups.tsx
@@ -45,11 +45,10 @@ export const FieldGroupList = () => {
           '.MuiFormLabel-asterisk': {color: 'red'},
         }}
       >
-        {<Typography variant="h5">{fieldGroup?.title}</Typography>}
+        <Typography variant="h5">{fieldGroup?.title}</Typography>
         {fields.map(field => {
           return (
             <Stack key={field.id} sx={{gap: 1}}>
-              <Typography variant="body1">{field.title}</Typography>
               <RenderFields
                 groupId={groupId}
                 field={field}
@@ -105,7 +104,7 @@ export const RenderFields = ({
           id="outlined"
           variant="outlined"
           placeholder="Type you answer here"
-          label="label needs to be added"
+          label={field.title}
           error={error}
           helperText={helperText}
           InputLabelProps={{
@@ -121,7 +120,7 @@ export const RenderFields = ({
           rows={4}
           id="outlined"
           placeholder="Type you answer here"
-          label="label needs to be added"
+          label={field.title}
           variant="outlined"
           error={error}
           helperText={helperText}
@@ -134,7 +133,7 @@ export const RenderFields = ({
     case 'number':
       return (
         <TextField
-          label="Phone Number"
+          label={field.title}
           {...props}
           error={error}
           helperText={helperText}
@@ -151,7 +150,7 @@ export const RenderFields = ({
       return (
         <TextField
           {...props}
-          label="Email"
+          label={field.title}
           error={error}
           helperText={helperText}
           id="outlined"
@@ -166,7 +165,7 @@ export const RenderFields = ({
     case 'yes_no':
       return (
         <FormControl error={error} required={field.validations.required}>
-          <FormLabel sx={{color: 'black'}}>Label needed</FormLabel>
+          <FormLabel sx={{color: 'black'}}>{field.title}</FormLabel>
           <RadioGroup {...props} row aria-labelledby="yes-no-field">
             <FormControlLabel value="yes" control={<Radio />} label="Yes" />
             <FormControlLabel value="no" control={<Radio />} label="No" />

--- a/app/src/components/intake-profile/IntakeProfileGroups.tsx
+++ b/app/src/components/intake-profile/IntakeProfileGroups.tsx
@@ -3,7 +3,9 @@ import {
   FormControl,
   FormControlLabel,
   FormHelperText,
+  InputLabel,
   MenuItem,
+  OutlinedInput,
   Radio,
   RadioGroup,
   Select,
@@ -90,13 +92,18 @@ export const RenderFields = ({
       return (
         <TextField
           {...props}
+          required
           multiline
           rows={1}
           id="outlined"
           variant="outlined"
           placeholder="Type you answer here"
+          label="label needs to be added"
           error={error}
           helperText={helperText}
+          InputLabelProps={{
+            shrink: true,
+          }}
         />
       );
     case 'long_text':
@@ -151,12 +158,16 @@ export const RenderFields = ({
         throw new Error('Invalid field type');
 
       return (
-        <FormControl fullWidth error={error}>
+        <FormControl fullWidth error={error} variant="outlined">
+          <InputLabel shrink required id="demo-simple-select-label">
+            Select a choice
+          </InputLabel>
           <Select
             {...props}
             labelId="demo-simple-select-label"
             id="demo-simple-select"
             displayEmpty
+            input={<OutlinedInput label="Select a choice" />}
             inputProps={{'aria-label': 'select-choice'}}
           >
             <MenuItem value="" disabled>

--- a/app/src/components/intake-profile/IntakeProfileGroups.tsx
+++ b/app/src/components/intake-profile/IntakeProfileGroups.tsx
@@ -45,7 +45,7 @@ export const FieldGroupList = () => {
           '.MuiFormLabel-asterisk': {color: 'red'},
         }}
       >
-        <Typography variant="h5">{fieldGroup?.title}</Typography>
+        {<Typography variant="h5">{fieldGroup?.title}</Typography>}
         {fields.map(field => {
           return (
             <Stack key={field.id} sx={{gap: 1}}>
@@ -99,7 +99,7 @@ export const RenderFields = ({
       return (
         <TextField
           {...props}
-          required
+          required={field.validations.required}
           multiline
           rows={1}
           id="outlined"
@@ -125,7 +125,7 @@ export const RenderFields = ({
           variant="outlined"
           error={error}
           helperText={helperText}
-          required
+          required={field.validations.required}
           InputLabelProps={{
             shrink: true,
           }}
@@ -141,7 +141,7 @@ export const RenderFields = ({
           id="outlined"
           placeholder="(909)555-1234"
           variant="outlined"
-          required
+          required={field.validations.required}
           InputLabelProps={{
             shrink: true,
           }}
@@ -157,7 +157,7 @@ export const RenderFields = ({
           id="outlined"
           placeholder="example@emai.com"
           variant="outlined"
-          required
+          required={field.validations.required}
           InputLabelProps={{
             shrink: true,
           }}
@@ -165,7 +165,7 @@ export const RenderFields = ({
       );
     case 'yes_no':
       return (
-        <FormControl error={error} required>
+        <FormControl error={error} required={field.validations.required}>
           <FormLabel sx={{color: 'black'}}>Label needed</FormLabel>
           <RadioGroup {...props} row aria-labelledby="yes-no-field">
             <FormControlLabel value="yes" control={<Radio />} label="Yes" />
@@ -180,7 +180,11 @@ export const RenderFields = ({
 
       return (
         <FormControl fullWidth error={error} variant="outlined">
-          <InputLabel shrink required id="demo-simple-select-label">
+          <InputLabel
+            shrink
+            required={field.validations.required}
+            id="demo-simple-select-label"
+          >
             Select a choice
           </InputLabel>
           <Select

--- a/app/src/components/intake-profile/IntakeProfileGroups.tsx
+++ b/app/src/components/intake-profile/IntakeProfileGroups.tsx
@@ -3,6 +3,7 @@ import {
   FormControl,
   FormControlLabel,
   FormHelperText,
+  FormLabel,
   InputLabel,
   MenuItem,
   OutlinedInput,
@@ -114,9 +115,14 @@ export const RenderFields = ({
           rows={4}
           id="outlined"
           placeholder="Type you answer here"
+          label="label needs to be added"
           variant="outlined"
           error={error}
           helperText={helperText}
+          required
+          InputLabelProps={{
+            shrink: true,
+          }}
         />
       );
     case 'number':
@@ -129,6 +135,10 @@ export const RenderFields = ({
           id="outlined"
           placeholder="(909)555-1234"
           variant="outlined"
+          required
+          InputLabelProps={{
+            shrink: true,
+          }}
         />
       );
     case 'email':
@@ -141,11 +151,16 @@ export const RenderFields = ({
           id="outlined"
           placeholder="example@emai.com"
           variant="outlined"
+          required
+          InputLabelProps={{
+            shrink: true,
+          }}
         />
       );
     case 'yes_no':
       return (
-        <FormControl error={error}>
+        <FormControl error={error} required>
+          <FormLabel sx={{color: 'black'}}>Label needed</FormLabel>
           <RadioGroup {...props} row aria-labelledby="yes-no-field">
             <FormControlLabel value="yes" control={<Radio />} label="Yes" />
             <FormControlLabel value="no" control={<Radio />} label="No" />

--- a/app/src/components/intake-profile/IntakeProfileGroups.tsx
+++ b/app/src/components/intake-profile/IntakeProfileGroups.tsx
@@ -38,7 +38,13 @@ export const FieldGroupList = () => {
 
   return (
     <Container maxWidth="sm" sx={{py: 4}}>
-      <Stack sx={{gap: 2}}>
+      <Stack
+        sx={{
+          gap: 2,
+          '.MuiInputLabel-asterisk': {color: 'red'},
+          '.MuiFormLabel-asterisk': {color: 'red'},
+        }}
+      >
         <Typography variant="h5">{fieldGroup?.title}</Typography>
         {fields.map(field => {
           return (


### PR DESCRIPTION
Closes #715 

### What changes did you make?
  - Added asterisk based on validation requiring the field
  - Overrided MUI asterisk color to match designs.
  - Redid the label per field.
### Rationale behind the changes?
  - Asterisk color was done local to the form and not to the whole website's theme to avoid confusion on color in future usage.
  - Modified how the field label was rendered since some field types required a label to make the asterisk work. Since I was already modifying the label, I made the change to render the label as ``field.title`` by handling them in the switch case to better match the figma designs.
### Testing done for these changes
  - Compared with ``db\profile.ts`` to make sure when validation was set to true/false, the asterisk rendered properly. 
### What did you learn or can share that is new?(optional)
- ``InputLabelProps={{shrink: true}}`` will make the field label inline to the border, but a label is needed to make it work. 

### Screenshots of Proposed Changes Of The Website  (if any, please do not screen shot code changes)
<!-- Note, if your images are too big, use the <img src="" width="" length="" />  syntax instead of ![image](link) to format the images -->
<!-- If images are not loading properly, you might need to double check the syntax or add a newline after the closing </summary> tag -->

<details>
<summary>Visuals before changes are applied</summary>

<img width="1048" alt="Screenshot 2024-06-22 at 7 58 51 PM" src="https://github.com/hackforla/HomeUniteUs/assets/104275658/45c8446f-0642-45d1-80ef-1854a58599e7">


</details>

<details>
<summary>Visuals after changes are applied</summary>
  
<img width="1036" alt="Screenshot 2024-06-22 at 7 57 32 PM" src="https://github.com/hackforla/HomeUniteUs/assets/104275658/8b5e5c67-3627-4c2a-8ed9-ef826f4409e2">


</details>