### PR TITLE
update run-tests with new directories

### DIFF
--- a/.github/workflows/run-tests-v1.yml
+++ b/.github/workflows/run-tests-v1.yml
@@ -11,7 +11,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: ./api
+        working-directory: ./flask-api
     steps:
       - uses: actions/checkout@main
         with:
@@ -44,7 +44,7 @@ jobs:
     defaults:
       run:
         shell: bash
-        working-directory: ./app
+        working-directory: ./frontend
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 20
@@ -62,5 +62,5 @@ jobs:
         with:
           install: false
           start: npm run dev
-          working-directory: ./app
+          working-directory: ./frontend
           wait-on: "http://[::1]:4040/"


### PR DESCRIPTION

### What changes did you make?
  I changed the directories in the github actions run-tests-v1.yml file. 
  
### Rationale behind the changes?
  The frontend and backend test suites are failing because the directories were recently updated and the failing cases are no longer visible. The goal is to get the test suite to run correctly and then identify what is causing the failing test cases before changing the testing workflow for the new backend. 
  
