### PR TITLE
Update run tests v1 github action frontend cache path

### DIFF
--- a/.github/workflows/run-tests-v1.yml
+++ b/.github/workflows/run-tests-v1.yml
@@ -52,10 +52,10 @@ jobs:
         with:
           node-version: 20
           cache: "npm"
-          cache-dependency-path: app/package-lock.json
+          cache-dependency-path: frontend/package-lock.json
       - name: Run npm CI
         run: npm ci
-      - name: Test app
+      - name: Test frontend
         run: npm run test -- --no-color --run
       - name: Run E2E tests
         uses: cypress-io/github-action@v5


### PR DESCRIPTION
Updates the npm cache dependency path using the updated directory name.

Related #789 

### What changes did you make?
  - Updated the frontend npm dependency cache path to use the updated frontend directory name.

### Rationale behind the changes?
  - The frontend code directory name was changed. This PR updates the location of the frontend code in the github action workflow. The npm cache dependency path was still using the previous frontend code location causing the action to fail.

### Testing done for these changes
  - Can be tested upon PR
  