### PR TITLE
Updated API Endpoints for Intake Profile and Dynamic Forms

### DIFF
--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -37,8 +37,10 @@ def setup_logging(settings: Settings):
                 )
 
         logging.basicConfig(handlers=[InterceptHandler()], level=0, force=True)
-
-        if settings.HUU_ENVIRONMENT.lower() in ["development", "qa", "local"]:
+        '''
+        A logging file can replace logging to standard out by changing sys.stdout to filename.log
+        '''
+        if settings.HUU_ENVIRONMENT.lower() in ["development", "local"]:
             logger.add(
                 sys.stdout,
                 format="<white>{time:YYYY-MM-DD HH:mm:ss}</white> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<green>{function}</green> - <white>{message}</white>",

--- a/backend/app/modules/deps.py
+++ b/backend/app/modules/deps.py
@@ -26,6 +26,7 @@ def get_form_1():
         import json
         with open("form_data/form1.json", "r") as f:
             FORM_1 = json.load(f)
+            FORM_1['id'] = 'guest'
     return FORM_1
 
 
@@ -35,6 +36,7 @@ def get_form_2():
         import json
         with open("form_data/form2.json", "r") as f:
             FORM_2 = json.load(f)
+            FORM_2['id'] = 'host'
     return FORM_2
 ################################################################################
 

--- a/backend/app/modules/intake_profile/controller.py
+++ b/backend/app/modules/intake_profile/controller.py
@@ -6,9 +6,9 @@ from app.modules.deps import DbSessionDep, get_form_1, get_form_2
 router = APIRouter()
 
 
-@router.put("/responses/{user_id}", status_code=status.HTTP_501_NOT_IMPLEMENTED)
-def update_intake_profile_responses(user_id, body, db_session: DbSessionDep):
-    pass
+# @router.put("/responses/{user_id}", status_code=status.HTTP_501_NOT_IMPLEMENTED)
+# def update_intake_profile_responses(user_id, body, db_session: DbSessionDep):
+#     pass
     # TODO: Implement update intake profile responses
     # with db_session.begin() as session:
     #     user_repo = UserRepository(session)
@@ -30,9 +30,9 @@ def update_intake_profile_responses(user_id, body, db_session: DbSessionDep):
     #     return {}, 204
 
 
-@router.get("/responses/{user_id}", status_code=status.HTTP_501_NOT_IMPLEMENTED)
-def get_intake_profile_responses(user_id, db_session: DbSessionDep):
-    pass
+# @router.get("/responses/{user_id}", status_code=status.HTTP_501_NOT_IMPLEMENTED)
+# def get_intake_profile_responses(user_id, db_session: DbSessionDep):
+#     pass
     # TODO: Implement get Intake Profile responses
     # with db_session.begin() as session:
     #     user_repo = UserRepository(session)
@@ -47,18 +47,20 @@ def get_intake_profile_responses(user_id, db_session: DbSessionDep):
     #     if responses:
     #         return responses, 200
     #     return [], 202
-@router.get("/form/{profile_type}", status_code=status.HTTP_200_OK)
-def get_intake_profile_form(profile_type: str,
-                            profile_form_1: Annotated[dict, Depends(get_form_1)],
-                            profile_form_2: Annotated[dict, Depends(get_form_2)]):
-    """Get the Intake Profile form definition for host or guest."""
-    if profile_type == "guest":
-        return profile_form_1
-    if profile_type == "host":
-        return profile_form_2
 
-    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
-                        detail=f"Form type {profile_type} does not exist.")
+# this is where i left off
+# @router.get("/responses/{profile_type}", status_code=status.HTTP_200_OK)
+# def get_intake_profile_form(profile_type: str,
+#                             profile_form_1: Annotated[dict, Depends(get_form_1)],
+#                             profile_form_2: Annotated[dict, Depends(get_form_2)]):
+#     """Get the Intake Profile form definition for host or guest."""
+#     if profile_type == "guest":
+#         return profile_form_1
+#     if profile_type == "host":
+#         return profile_form_2
+
+#     raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+#                         detail=f"Form type {profile_type} does not exist.")
 
 
 # @router.get("/form/{profile_id}", status_code=status.HTTP_200_OK)
@@ -73,3 +75,30 @@ def get_intake_profile_form(profile_type: str,
 
 #     raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
 #                         detail=f"Form with id {profile_id} does not exist.")
+
+
+from typing import Annotated
+from fastapi import APIRouter, HTTPException, status, Depends
+
+from app.modules.deps import DbSessionDep, get_form_1, get_form_2
+
+router = APIRouter()
+
+@router.get("/form/{profile_type}", status_code=status.HTTP_200_OK)
+def get_intake_profile_form(profile_type: str,
+                            profile_form_1: Annotated[dict, Depends(get_form_1)],
+                            profile_form_2: Annotated[dict, Depends(get_form_2)]):
+    """Get the Intake Profile form definition and responses for host or guest."""
+    if profile_type == "guest":
+        return {
+            "form": profile_form_1,
+            "responses": profile_form_1.get("responses", [])
+        }
+    if profile_type == "host":
+        return {
+            "form": profile_form_2,
+            "responses": profile_form_2.get("responses", [])
+        }
+
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                        detail=f"Form type {profile_type} does not exist.")

--- a/backend/app/modules/intake_profile/controller.py
+++ b/backend/app/modules/intake_profile/controller.py
@@ -61,15 +61,15 @@ def get_intake_profile_form(profile_type: str,
                         detail=f"Form type {profile_type} does not exist.")
 
 
-@router.get("/form/{profile_id}", status_code=status.HTTP_200_OK)
-def get_intake_profile_form(profile_id: int,
-                            profile_form_1: Annotated[str, Depends(get_form_1)],
-                            profile_form_2: Annotated[str, Depends(get_form_2)]):
-    """Get the Intake Profile form definition."""
-    if profile_id == 1:
-        return profile_form_1
-    if profile_id == 2:
-        return profile_form_2
+# @router.get("/form/{profile_id}", status_code=status.HTTP_200_OK)
+# def get_intake_profile_form(profile_id: int,
+#                             profile_form_1: Annotated[str, Depends(get_form_1)],
+#                             profile_form_2: Annotated[str, Depends(get_form_2)]):
+#     """Get the Intake Profile form definition."""
+#     if profile_id == 1:
+#         return profile_form_1
+#     if profile_id == 2:
+#         return profile_form_2
 
-    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
-                        detail=f"Form with id {profile_id} does not exist.")
+#     raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+#                         detail=f"Form with id {profile_id} does not exist.")

--- a/backend/app/modules/intake_profile/controller.py
+++ b/backend/app/modules/intake_profile/controller.py
@@ -47,6 +47,18 @@ def get_intake_profile_responses(user_id, db_session: DbSessionDep):
     #     if responses:
     #         return responses, 200
     #     return [], 202
+@router.get("/form/{profile_type}", status_code=status.HTTP_200_OK)
+def get_intake_profile_form(profile_type: str,
+                            profile_form_1: Annotated[dict, Depends(get_form_1)],
+                            profile_form_2: Annotated[dict, Depends(get_form_2)]):
+    """Get the Intake Profile form definition for host or guest."""
+    if profile_type == "guest":
+        return profile_form_1
+    if profile_type == "host":
+        return profile_form_2
+
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                        detail=f"Form type {profile_type} does not exist.")
 
 
 @router.get("/form/{profile_id}", status_code=status.HTTP_200_OK)

--- a/backend/form_data/form1.json
+++ b/backend/form_data/form1.json
@@ -1,1 +1,344 @@
-{"id":"1","fieldGroups":[{"id":"1293","title":"Basic Information","fields":[{"id":"3922","title":"First Name","type":"short_text","properties":{},"validations":{"required":true}},{"id":"5572","title":"Last Name","type":"short_text","properties":{},"validations":{"required":true}},{"id":"2188","title":"Date of Birth","type":"date","properties":{},"validations":{"required":true}},{"id":"3924","title":"Gender Identity","type":"dropdown","properties":{"choices":[{"id":"1359","label":"Woman"},{"id":"5342","label":"Man"},{"id":"3151","label":"Questioning"},{"id":"2178","label":"Transgender"},{"id":"3667","label":"Non-binary"},{"id":"3708","label":"Doesn’t know or prefers not to answer\\t"}]},"validations":{"required":true}}]},{"id":"1348","title":"Contact Information","fields":[{"id":"7813","title":"Email","type":"email","properties":{},"validations":{"required":true}},{"id":"2044","title":"Phone Number","type":"number","properties":{},"validations":{"required":true}},{"id":"7504","title":"What is the best way to contact you?","type":"contact_method","properties":{},"validations":{"required":true},"linkedFields":{"emailFieldId":"3158","phoneFieldId":"9365"}}]},{"id":"6577","title":"Other Guests/Pets","fields":[{"id":"7709","title":"Additional Guests","type":"additional_guests","properties":{},"validations":{}},{"id":"7740","title":"Do you have any pets in your care?","type":"yes_no","properties":{},"validations":{"required":true}},{"id":"5056","title":"Pet Type","type":"pets","properties":{},"validations":{"required":false}}]},{"id":"1676","title":"Employment Information","fields":[{"id":"5478","title":"Are you currently employed?","type":"yes_no","properties":{},"validations":{"required":true}},{"id":"8533","title":"If yes, please describe your employment.","type":"long_text","properties":{},"validations":{"required_if":{"field_id":"5478","value":"yes"}}},{"id":"8487","title":"If no, are you currently looking for work? If so, what type?","type":"long_text","properties":{},"validations":{"required_if":{"field_id":"5478","value":"no"}}}]},{"id":"5996","title":"Education","fields":[{"id":"6478","title":"Are you enrolled in an Educational Program?","type":"yes_no","properties":{},"validations":{"required":true}},{"id":"7222","title":"If yes, please describe the program.","type":"long_text","properties":{},"validations":{"required_if":{"field_id":"6478","value":"yes"}}},{"id":"7661","title":"If no, are you hoping to enroll in an Educational Program? If so, what type?","type":"long_text","properties":{},"validations":{"required_if":{"field_id":"6478","value":"no"}}}]},{"id":"4480","title":"Language Proficiency","fields":[{"id":"5479","title":"Are you bilingual or multilingual?","type":"yes_no","properties":{},"validations":{"required":true}},{"id":"2359","title":"If yes, what languages do you speak?","type":"long_text","properties":{},"validations":{"required_if":{"field_id":"5479","value":"yes"}}}]},{"id":"5282","title":"Substance Use","fields":[{"id":"8229","title":"Do you smoke cigarettes?","type":"yes_no","properties":{},"validations":{"required":true}},{"id":"7844","title":"Do you drink alcohol?","type":"yes_no","properties":{},"validations":{"required":true}},{"id":"7494","title":"Do you use any other substances?","type":"yes_no","properties":{},"validations":{"required":true}}]},{"id":"3691","title":"Mental Health","fields":[{"id":"3831","title":"Do you suffer mental illness?","type":"yes_no","properties":{},"validations":{"required":true}}]},{"id":"7816","title":"Interest in Being a Guest","fields":[{"id":"1885","title":"Please share how you think participating in the Host Homes Program will help you obtain long-term housing and meet your educational and/or employment goals:","type":"long_text","properties":{},"validations":{"required":true}},{"id":"1185","title":"What kind of relationship do you hope to have with your host home?","type":"long_text","properties":{},"validations":{"required":true}},{"id":"3749","title":"Please describe any challenges you foresee encountering in participating in the Host Homes Program.","type":"long_text","properties":{},"validations":{"required":true}}]},{"id":"8837","title":"About You","fields":[{"id":"3411","title":"Please take some time to write an introduction of yourself that you would feel comfortable with the Host Homes Coordinator sharing with a potential host. Feel free to talk about your interests, your story or anything else that you think would be important to share:","type":"long_text","properties":{},"validations":{"required":true}}]}]}
+{
+    "id": "1",
+    "fieldGroups": [
+      {
+        "id": "1293",
+        "title": "Basic Information",
+        "fields": [
+          {
+            "id": "3922",
+            "title": "First Name",
+            "type": "short_text",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          },
+          {
+            "id": "5572",
+            "title": "Last Name",
+            "type": "short_text",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          },
+          {
+            "id": "2188",
+            "title": "Date of Birth",
+            "type": "date",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          },
+          {
+            "id": "3924",
+            "title": "Gender Identity",
+            "type": "dropdown",
+            "properties": {
+              "choices": [
+                {
+                  "id": "1359",
+                  "label": "Woman"
+                },
+                {
+                  "id": "5342",
+                  "label": "Man"
+                },
+                {
+                  "id": "3151",
+                  "label": "Questioning"
+                },
+                {
+                  "id": "2178",
+                  "label": "Transgender"
+                },
+                {
+                  "id": "3667",
+                  "label": "Non-binary"
+                },
+                {
+                  "id": "3708",
+                  "label": "Doesn’t know or prefers not to answer"
+                }
+              ]
+            },
+            "validations": {
+              "required": true
+            }
+          }
+        ]
+      },
+      {
+        "id": "1348",
+        "title": "Contact Information",
+        "fields": [
+          {
+            "id": "7813",
+            "title": "Email",
+            "type": "email",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          },
+          {
+            "id": "2044",
+            "title": "Phone Number",
+            "type": "number",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          },
+          {
+            "id": "7504",
+            "title": "What is the best way to contact you?",
+            "type": "contact_method",
+            "properties": {},
+            "validations": {
+              "required": true
+            },
+            "linkedFields": {
+              "emailFieldId": "7813",
+              "phoneFieldId": "2044"
+            }
+          }
+        ]
+      },
+      {
+        "id": "6577",
+        "title": "Other Guests/Pets",
+        "fields": [
+          {
+            "id": "7709",
+            "title": "Additional Guests",
+            "type": "additional_guests",
+            "properties": {},
+            "validations": {}
+          },
+          {
+            "id": "7740",
+            "title": "Do you have any pets in your care?",
+            "type": "yes_no",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          },
+          {
+            "id": "5056",
+            "title": "Pet Type",
+            "type": "pets",
+            "properties": {},
+            "validations": {
+              "required": false
+            }
+          }
+        ]
+      },
+      {
+        "id": "1676",
+        "title": "Employment Information",
+        "fields": [
+          {
+            "id": "5478",
+            "title": "Are you currently employed?",
+            "type": "yes_no",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          },
+          {
+            "id": "8533",
+            "title": "If yes, please describe your employment.",
+            "type": "long_text",
+            "properties": {},
+            "validations": {
+              "required_if": {
+                "field_id": "5478",
+                "value": "yes"
+              }
+            }
+          },
+          {
+            "id": "8487",
+            "title": "If no, are you currently looking for work? If so, what type?",
+            "type": "long_text",
+            "properties": {},
+            "validations": {
+              "required_if": {
+                "field_id": "5478",
+                "value": "no"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": "5996",
+        "title": "Education",
+        "fields": [
+          {
+            "id": "6478",
+            "title": "Are you enrolled in an Educational Program?",
+            "type": "yes_no",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          },
+          {
+            "id": "7222",
+            "title": "If yes, please describe the program.",
+            "type": "long_text",
+            "properties": {},
+            "validations": {
+              "required_if": {
+                "field_id": "6478",
+                "value": "yes"
+              }
+            }
+          },
+          {
+            "id": "7661",
+            "title": "If no, are you hoping to enroll in an Educational Program? If so, what type?",
+            "type": "long_text",
+            "properties": {},
+            "validations": {
+              "required_if": {
+                "field_id": "6478",
+                "value": "no"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": "4480",
+        "title": "Language Proficiency",
+        "fields": [
+          {
+            "id": "5479",
+            "title": "Are you bilingual or multilingual?",
+            "type": "yes_no",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          },
+          {
+            "id": "2359",
+            "title": "If yes, what languages do you speak?",
+            "type": "long_text",
+            "properties": {},
+            "validations": {
+              "required_if": {
+                "field_id": "5479",
+                "value": "yes"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "id": "5282",
+        "title": "Substance Use",
+        "fields": [
+          {
+            "id": "8229",
+            "title": "Do you smoke cigarettes?",
+            "type": "yes_no",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          },
+          {
+            "id": "7844",
+            "title": "Do you drink alcohol?",
+            "type": "yes_no",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          },
+          {
+            "id": "7494",
+            "title": "Do you use any other substances?",
+            "type": "yes_no",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          }
+        ]
+      },
+      {
+        "id": "3691",
+        "title": "Mental Health",
+        "fields": [
+          {
+            "id": "3831",
+            "title": "Do you suffer mental illness?",
+            "type": "yes_no",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          }
+        ]
+      },
+      {
+        "id": "7816",
+        "title": "Interest in Being a Guest",
+        "fields": [
+          {
+            "id": "1885",
+            "title": "Please share how you think participating in the Host Homes Program will help you obtain long-term housing and meet your educational and/or employment goals:",
+            "type": "long_text",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          },
+          {
+            "id": "1185",
+            "title": "What kind of relationship do you hope to have with your host home?",
+            "type": "long_text",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          },
+          {
+            "id": "3749",
+            "title": "Please describe any challenges you foresee encountering in participating in the Host Homes Program.",
+            "type": "long_text",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          }
+        ]
+      },
+      {
+        "id": "8837",
+        "title": "About You",
+        "fields": [
+          {
+            "id": "3411",
+            "title": "Please take some time to write an introduction of yourself that you would feel comfortable with the Host Homes Coordinator sharing with a potential host. Feel free to talk about your interests, your story or anything else that you think would be important to share:",
+            "type": "long_text",
+            "properties": {},
+            "validations": {
+              "required": true
+            }
+          }
+        ]
+      }
+    ]
+  }
+  

--- a/frontend/src/features/authentication/SignInForm.tsx
+++ b/frontend/src/features/authentication/SignInForm.tsx
@@ -26,9 +26,9 @@ const validationSchema = object({
 });
 
 export const SignInForm = ({
-  onSubmit, 
+  onSubmit,
   isLoading,
-  getTokenIsLoading
+  getTokenIsLoading,
 }: SignInFormProps) => {
   const {
     handleSubmit,

--- a/frontend/src/features/authentication/SignUpForm.tsx
+++ b/frontend/src/features/authentication/SignUpForm.tsx
@@ -34,7 +34,7 @@ export const SignUpForm = ({
   type,
   getTokenIsLoading = false,
   signUpHostIsLoading = false,
-  signUpCoordinatorIsLoading = false
+  signUpCoordinatorIsLoading = false,
 }: SignUpFormProps) => {
   const isAnyLoading =
     isLoading ||

--- a/frontend/src/features/intake-profile/IntakeProfileGroups.tsx
+++ b/frontend/src/features/intake-profile/IntakeProfileGroups.tsx
@@ -217,18 +217,19 @@ export const RenderFields = ({groupId, field}: RenderFieldProps) => {
     case 'contact_method':
       // eslint-disable-next-line no-case-declarations
       const {emailFieldId, phoneFieldId} = field.linkedFields || {};
+
       // eslint-disable-next-line no-case-declarations
       let isEmailFilled = false;
       // eslint-disable-next-line no-case-declarations
       let isPhoneFilled = false;
       if (emailFieldId) {
-        const emailValue = values[emailFieldId];
+        const emailValue = values[groupId][emailFieldId];
         isEmailFilled =
           typeof emailValue === 'string' && /\S+@\S+\.\S+/.test(emailValue);
       }
       // eslint-disable-next-line no-case-declarations
       if (phoneFieldId) {
-        const phoneValue = values[phoneFieldId];
+        const phoneValue = values[groupId][phoneFieldId];
         isPhoneFilled =
           typeof phoneValue === 'string' && phoneRegExp.test(phoneValue);
       }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -43,7 +43,7 @@ import {
   IntakeProfile,
 } from './pages';
 import {SystemAdminDashboard} from './pages/SystemAdminDashboard';
-import {enableMocking} from './utils/testing/browser';
+// import {enableMocking} from './utils/testing/browser';
 import {useAppDispatch} from './redux/hooks/store';
 import {setCredentials} from './redux/authSlice';
 import NotFound from './pages/NotFound';
@@ -162,21 +162,21 @@ function HuuApp() {
 
 const appRoot = document.getElementById('root') as HTMLElement;
 
-enableMocking().then(() => {
-  ReactDOM.createRoot(appRoot).render(
-    <React.StrictMode>
-      <Provider store={setupStore()}>
-        <BrowserRouter>
-          <LocalizationProvider dateAdapter={AdapterDateFns}>
-            <StyledEngineProvider injectFirst>
-              <ThemeProvider theme={HomeUniteUsTheme}>
-                <CssBaseline />
-                <HuuApp />
-              </ThemeProvider>
-            </StyledEngineProvider>
-          </LocalizationProvider>
-        </BrowserRouter>
-      </Provider>
-    </React.StrictMode>,
-  );
-});
+// enableMocking().then(() => {
+ReactDOM.createRoot(appRoot).render(
+  <React.StrictMode>
+    <Provider store={setupStore()}>
+      <BrowserRouter>
+        <LocalizationProvider dateAdapter={AdapterDateFns}>
+          <StyledEngineProvider injectFirst>
+            <ThemeProvider theme={HomeUniteUsTheme}>
+              <CssBaseline />
+              <HuuApp />
+            </ThemeProvider>
+          </StyledEngineProvider>
+        </LocalizationProvider>
+      </BrowserRouter>
+    </Provider>
+  </React.StrictMode>,
+);
+// });

--- a/frontend/src/pages/authentication/SignUp.tsx
+++ b/frontend/src/pages/authentication/SignUp.tsx
@@ -18,24 +18,32 @@ import {
 import {isErrorWithMessage, isFetchBaseQueryError} from '../../redux/helpers';
 import {useAuthenticateWithOAuth} from '../../features/authentication/hooks/useAuthenticateWithOAuth';
 import {FormContainer, SignUpForm} from '../../features/authentication';
-import { LocationState } from './SignIn';
+// Uncomment this import if it's in a separate file
+// import { LocationState } from './SignIn';
+
+// You might need to define LocationState if it's not imported
+interface LocationState {
+  from?: {
+    pathname: string;
+  };
+}
 
 export const SignUp = () => {
   const [errorMessage, setErrorMessage] = React.useState('');
   const {type} = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
+
+  // Get location state information
+  const locationState = location.state as LocationState;
+
+  // Save location from which user was redirected to login page
+  const from = locationState?.from?.pathname || '/';
 
   const [signUp, {isLoading: signUpIsLoading}] = useSignUpMutation();
 
   const [googleSignUp, {isLoading: getTokenIsLoading}] =
     useGoogleSignUpMutation();
-
-    // const location = useLocation()
-    // // get type from params
-    // const locationState = location.state as LocationState;
-
-    // // Save location from which user was redirected to login page
-    // const from = locationState?.from?.pathname || '/';
 
   const callbackUri = `/signup/${type}`;
   useAuthenticateWithOAuth({
@@ -63,7 +71,8 @@ export const SignUp = () => {
         role: type,
       }).unwrap();
 
-      navigate(`/signup/success?email=${email}`);
+      // Navigate to success page, passing along the original location
+      navigate(`/signup/success?email=${email}`, {state: {from}});
     } catch (err) {
       if (isFetchBaseQueryError(err)) {
         const errMsg = err.data?.detail?.message || 'Failed to sign up';

--- a/frontend/src/pages/intake-profile/IntakeProfile.tsx
+++ b/frontend/src/pages/intake-profile/IntakeProfile.tsx
@@ -1,18 +1,21 @@
-import {Button, Stack, useMediaQuery, useTheme} from '@mui/material';
+import React, {useState, useEffect} from 'react';
+import {
+  Button,
+  Stack,
+  useMediaQuery,
+  useTheme,
+  CircularProgress,
+  Typography,
+} from '@mui/material';
 import {Outlet, useLocation, useNavigate, useParams} from 'react-router-dom';
 import {Formik} from 'formik';
 import {buildValidationSchema, createInitialValues} from './helpers';
-import {
-  useGetProfileQuery,
-  useGetResponsesQuery,
-  Response,
-} from '../../services/profile';
-import {useState} from 'react';
+import {useGetProfileQuery, Response} from '../../services/profile';
 import {ProfileSidebar} from '../../features/intake-profile';
+
 export type Values = {
   [key: string]: Response['value'];
 };
-import {useEffect} from 'react';
 
 export type InitialValues = Record<string, Values>;
 
@@ -20,49 +23,100 @@ export const IntakeProfile = () => {
   const theme = useTheme();
   const navigate = useNavigate();
   const toolbarHeight = Number(theme.mixins.toolbar.minHeight);
-  const {profileId, groupId} = useParams();
+  const params = useParams();
   const location = useLocation();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [showSections, setShowSections] = useState(isMobile);
   const [selectedItem, setSelectedItem] = useState<string | null>(
-    groupId || null,
+    params.groupId || null,
   );
 
-  const {data: profileData} = useGetProfileQuery(
-    {profileId: profileId},
-    {skip: !profileId},
-  );
-
-  const {data: responsesData} = useGetResponsesQuery({userId: 'guest'});
-
+  // Debug logging for all parameters
   useEffect(() => {
-    console.log('Profile ID:', profileId);
-    console.log('Group ID:', groupId);
-    console.log('Profile Data:', profileData);
-    console.log('Responses Data:', responsesData);
-    console.log('URL Path:', location.pathname);
-  }, [profileId, groupId, profileData, responsesData, location]);
+    console.log('FULL ROUTE PARAMETERS:', params);
+    console.log('CURRENT LOCATION:', location);
+  }, [params, location]);
 
-  if (
-    profileId === undefined ||
-    profileData === undefined ||
-    responsesData === undefined
-  )
-    return null;
+  // Determine profile type with extensive fallback
+  const profileType =
+    params.profileType || params.profileId?.split('-')[0] || 'guest';
 
-  const {fieldGroups} = profileData;
-  const {responses} = responsesData;
+  // const userId =
+  //   params.userId ||
+  //   (params.profileId?.split('-')[1]) ||
+  //   'anonymous';
 
-  // create validation schema for current group. Return empty object if groupId is undefined, which means we are on welcome or review page
+  // Fetch profile data
+  const {
+    data: profileData,
+    isLoading: isProfileLoading,
+    error: profileError,
+  } = useGetProfileQuery({
+    profileId: profileType,
+  });
+
+  // Extensive error logging
+  useEffect(() => {
+    if (profileError) {
+      console.error('PROFILE FETCH ERROR:', profileError);
+    }
+  }, [profileError]);
+
+  // Loading state
+  if (isProfileLoading) {
+    return (
+      <Stack justifyContent="center" alignItems="center" sx={{height: '100vh'}}>
+        <CircularProgress />
+      </Stack>
+    );
+  }
+
+  // Error handling
+  if (profileError) {
+    return (
+      <Stack
+        justifyContent="center"
+        alignItems="center"
+        sx={{height: '100vh', color: 'error.main'}}
+      >
+        <Typography variant="h6">
+          Error loading profile. Please try again.
+        </Typography>
+        <Typography variant="body2">{JSON.stringify(profileError)}</Typography>
+      </Stack>
+    );
+  }
+
+  // If no data after loading, return null or show error
+  if (!profileData) {
+    return (
+      <Stack
+        justifyContent="center"
+        alignItems="center"
+        sx={{height: '100vh', color: 'error.main'}}
+      >
+        <Typography variant="h6">No profile data found</Typography>
+      </Stack>
+    );
+  }
+
+  const {form, responses = []} = profileData;
+  const fieldGroups = form?.fieldGroups || [];
+
+  // create validation schema for current group
   const validationSchema =
-    groupId === undefined ? {} : buildValidationSchema(fieldGroups, groupId);
+    params.groupId === undefined
+      ? {}
+      : buildValidationSchema(fieldGroups, params.groupId);
 
   // create initial values from responses and fieldGroups
-  const initalValues = createInitialValues(fieldGroups, responses);
+  const initialValues = createInitialValues(fieldGroups, responses);
+
   const currentIndex = fieldGroups.findIndex(
     group => group.id === selectedItem,
   );
 
+  // Navigation and section management functions
   function toggleShowSections() {
     setShowSections(!showSections);
   }
@@ -72,7 +126,6 @@ export const IntakeProfile = () => {
       const nextGroupId = fieldGroups[currentIndex + 1].id;
       setSelectedItem(nextGroupId);
       navigate(`group/${nextGroupId}`);
-      //need to add autosave feature
     }
   }
 
@@ -81,33 +134,35 @@ export const IntakeProfile = () => {
       const prevGroupId = fieldGroups[currentIndex - 1].id;
       setSelectedItem(prevGroupId);
       navigate(`group/${prevGroupId}`);
-      //need to add autosave feature
     }
   }
 
   const handleSubmitApplication = () => {
-    // submit the application after review
+    // TODO: Implement application submission logic
+    console.log('Submitting application');
   };
 
   return (
     <Formik
-      initialValues={initalValues}
+      initialValues={initialValues}
       validationSchema={validationSchema}
       enableReinitialize={true}
       onSubmit={values => {
-        if (!groupId) {
+        if (!params.groupId) {
           console.error('groupId is not defined in on submit');
           return;
         }
 
-        const updateResponses = Object.entries(values[groupId]).map(
+        const updateResponses = Object.entries(values[params.groupId]).map(
           ([fieldId, value]) => {
             const response = responses.find(
               response => response.fieldId === fieldId,
             );
             if (response) {
-              response.value = value;
-              return response;
+              return {
+                ...response,
+                value,
+              };
             } else {
               return {
                 fieldId,
@@ -130,7 +185,7 @@ export const IntakeProfile = () => {
         >
           <ProfileSidebar
             fieldGroups={fieldGroups}
-            groupId={groupId}
+            groupId={params.groupId}
             isReviewPage={location.pathname.includes('review')}
             toggleShowSections={toggleShowSections}
             setSelectedItem={setSelectedItem}
@@ -146,7 +201,9 @@ export const IntakeProfile = () => {
             }}
           >
             <Stack sx={{overflowY: 'auto'}}>
-              <Outlet context={{groupId, fieldGroups, errors}} />
+              <Outlet
+                context={{groupId: params.groupId, fieldGroups, errors}}
+              />
             </Stack>
             <Stack
               sx={{

--- a/frontend/src/pages/intake-profile/IntakeProfile.tsx
+++ b/frontend/src/pages/intake-profile/IntakeProfile.tsx
@@ -12,6 +12,7 @@ import {ProfileSidebar} from '../../features/intake-profile';
 export type Values = {
   [key: string]: Response['value'];
 };
+import {useEffect} from 'react';
 
 export type InitialValues = Record<string, Values>;
 
@@ -31,7 +32,16 @@ export const IntakeProfile = () => {
     {profileId: profileId},
     {skip: !profileId},
   );
-  const {data: responsesData} = useGetResponsesQuery({userId: '1'});
+
+  const {data: responsesData} = useGetResponsesQuery({userId: 'guest'});
+
+  useEffect(() => {
+    console.log('Profile ID:', profileId);
+    console.log('Group ID:', groupId);
+    console.log('Profile Data:', profileData);
+    console.log('Responses Data:', responsesData);
+    console.log('URL Path:', location.pathname);
+  }, [profileId, groupId, profileData, responsesData, location]);
 
   if (
     profileId === undefined ||

--- a/frontend/src/pages/intake-profile/helpers/createInitialValues.ts
+++ b/frontend/src/pages/intake-profile/helpers/createInitialValues.ts
@@ -2,7 +2,7 @@ import {FieldGroup, FieldTypes, Response} from '../../../services/profile';
 import {InitialValues} from '../IntakeProfile';
 
 /**
- * Creates an object used for the initial Formik valiues
+ * Creates an object used for the initial Formik values
  * It takes the form of:
  * {
  *  fieldGroupId: {
@@ -30,22 +30,39 @@ const fieldDefaultValue = (fieldType: FieldTypes) => {
       return '';
     case 'yes_no':
       return '';
+    case 'multiple_choice':
+      return [];
+    case 'contact_method':
+      return '';
     default:
       return '';
   }
 };
 
 export const createInitialValues = (
-  fieldGroups: FieldGroup[],
-  responses: Response[],
+  fieldGroups: FieldGroup[] | undefined,
+  responses: Response[] | undefined,
 ): InitialValues => {
+  // Early return if fieldGroups is undefined or empty
+  if (!fieldGroups || fieldGroups.length === 0) {
+    return {};
+  }
+
+  // Use empty array if responses is undefined
+  const safeResponses = responses || [];
+
   return fieldGroups.reduce((acc: InitialValues, fieldGroup) => {
-    const fields = fieldGroup.fields.reduce((acc, field) => {
+    // Skip groups without fields
+    if (!fieldGroup.fields || fieldGroup.fields.length === 0) {
+      return acc;
+    }
+
+    const fields = fieldGroup.fields.reduce((fieldAcc, field) => {
       return {
-        ...acc,
+        ...fieldAcc,
         [field.id]:
-          responses.find(response => response.fieldId === field.id)?.value ||
-          fieldDefaultValue(field.type),
+          safeResponses.find(response => response.fieldId === field.id)
+            ?.value || fieldDefaultValue(field.type),
       };
     }, {});
 

--- a/frontend/src/services/profile.ts
+++ b/frontend/src/services/profile.ts
@@ -65,7 +65,7 @@ export interface Guest {
 }
 
 export interface Response {
-  id: string;
+  id?: string;
   fieldId: string;
   value: string | Guest[] | Pet[] | undefined;
 }
@@ -82,14 +82,6 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/intake-profile/form/${queryArg.profileId}`,
       }),
     }),
-    getResponses: build.query<
-      GetProfileResponsesApiResponse,
-      GetProfileResponsesApiArg
-    >({
-      query: queryArg => ({
-        url: `/intake-profile/responses/${queryArg.userId}`,
-      }),
-    }),
   }),
   overrideExisting: false,
 });
@@ -99,18 +91,11 @@ export {injectedRtkApi as hostAPI};
 export interface GetProfileApiResponse {
   id: string;
   fieldGroups: FieldGroup[];
+  responses?: Response[];
 }
 
 export interface GetProfileApiArg {
-  profileId: string | undefined;
+  profileId: string;
 }
 
-export interface GetProfileResponsesApiResponse {
-  responses: Response[];
-}
-
-export interface GetProfileResponsesApiArg {
-  userId: string | undefined;
-}
-
-export const {useGetProfileQuery, useGetResponsesQuery} = injectedRtkApi;
+export const {useGetProfileQuery} = injectedRtkApi;

--- a/frontend/src/utils/testing/handlers/profile.ts
+++ b/frontend/src/utils/testing/handlers/profile.ts
@@ -7,37 +7,65 @@ interface GetResponsesParams {
   userId: string;
 }
 
+// export const handlers = [
+//   http.get('/api/intake-profile/form/:profileId', req => {
+//     const id = req.params.profileId;
+//     const profile = intakeProfiles.find(p => p.id === id);
+
+//     if (profile) {
+//       return HttpResponse.json(profile);
+//     }
+
+//     return new HttpResponse(null, {status: 404});
+//   }),
+
+//   http.get<GetResponsesParams, GetProfileResponsesApiResponse>(
+//     '/api/intake-profile/responses/:userId',
+//     () => {
+//       const fields = intakeProfiles[0].fieldGroups
+//         .map(fieldGroup => fieldGroup.fields)
+//         .flat();
+
+//       const responses = fields.map(field => {
+//         const value = getResponseValue(field);
+//         return {
+//           fieldId: field.id,
+//           value,
+//         };
+//       });
+
+//       // return a list of filled in responses
+//       return HttpResponse.json({responses});
+//       // return an empty list of responses
+//       // return HttpResponse.json({responses: []});
+//     },
+//   ),
+// ];
+
 export const handlers = [
-  http.get('/api/intake-profile/form/:profileId', req => {
-    const id = req.params.profileId;
-    const profile = intakeProfiles.find(p => p.id === id);
-
-    if (profile) {
-      return HttpResponse.json(profile);
-    }
-
-    return new HttpResponse(null, {status: 404});
-  }),
-
   http.get<GetResponsesParams, GetProfileResponsesApiResponse>(
-    '/api/intake-profile/responses/:userId',
-    () => {
-      const fields = intakeProfiles[0].fieldGroups
-        .map(fieldGroup => fieldGroup.fields)
-        .flat();
+    '/api/intake-profile/responses/:profile_type',
+    req => {
+      const profileType = req.params.userId;
+      const profile = intakeProfiles.find(p => p.id === profileType);
 
-      const responses = fields.map(field => {
-        const value = getResponseValue(field);
-        return {
-          fieldId: field.id,
-          value,
-        };
-      });
+      if (profile) {
+        const fields = profile.fieldGroups
+          .map(fieldGroup => fieldGroup.fields)
+          .flat();
 
-      // return a list of filled in responses
-      return HttpResponse.json({responses});
-      // return an empty list of responses
-      // return HttpResponse.json({responses: []});
+        const responses = fields.map(field => {
+          const value = getResponseValue(field);
+          return {
+            fieldId: field.id,
+            value,
+          };
+        });
+
+        return HttpResponse.json({responses});
+      }
+
+      return new HttpResponse(null, {status: 404});
     },
   ),
 ];


### PR DESCRIPTION
This PR is a work in progress. 

### What changes did you make?
- Temporarily removed mock service worker (MSW) temporarily.
- Updated intake-profile controller to return json document for dynamic form elements.
- Changed fetch requests to match api handler
- Altered path in main.tsx allowing user to navigate to other forms based on updated path
- Fixed json file for the contact method fields, and the contact method input component to retrieve the correct field id. 
- Removed color formatting in JSON logs for QA environments in AWS.


### Rationale behind the changes?

Dynamic forms are being implemented to display application information. This approach is intended for both Host and Guest applications, reducing the need for custom form components and promoting code reuse.

### Testing done for these changes

Testing will be completed once the functionality is confirmed.


### What can you share that is new?

**Note** This probably wasn't the intended application. I believe there are a number of changes needed including:

1. The path from the guest dashboard using the correct group id and profile id. 
  // Old url: 'profile/1/group/1' vs  New url: 'profile/guest'
  
2. the userId vs profileType in api requests

 '/api/intake-profile/responses/:profile_type' vs  '/api/intake-profile/responses/:userId',

The paths were updated  to 'guest' and 'host' from 1 and 2. 

Guest Application
<img width="1112" alt="Screen Shot 2025-03-01 at 9 49 25 PM" src="https://github.com/user-attachments/assets/996c9fc8-129c-40fb-b7e5-a4c8e8763e1e" />

Host Application
<img width="1104" alt="Screen Shot 2025-03-01 at 9 50 20 PM" src="https://github.com/user-attachments/assets/dcbccbbb-52fa-4191-9a7d-4b2ac6b55ff6" />



****